### PR TITLE
[feat] 물건 목록 조회 Repository 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.1'
@@ -34,6 +40,27 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // query DSL 의존성 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+//-- Query DSL generated path --//
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/swapit/config/QueryDslConfig.java
+++ b/src/main/java/com/example/swapit/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package com.example.swapit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+	@PersistenceContext
+	private final EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/main/java/com/example/swapit/controller/GoodsController.java
+++ b/src/main/java/com/example/swapit/controller/GoodsController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +21,8 @@ import com.example.swapit.service.GoodsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@RestController("/api")
+@RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class GoodsController {
 

--- a/src/main/java/com/example/swapit/controller/GoodsController.java
+++ b/src/main/java/com/example/swapit/controller/GoodsController.java
@@ -1,15 +1,19 @@
 package com.example.swapit.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.GoodsDetailDto;
+import com.example.swapit.domain.dto.GoodsListDto;
 import com.example.swapit.domain.dto.GoodsRequestDto;
 import com.example.swapit.service.GoodsService;
 
@@ -21,6 +25,18 @@ import lombok.RequiredArgsConstructor;
 public class GoodsController {
 
 	private final GoodsService goodsService;
+
+	@GetMapping("/all/goods")
+	public ApiResponse<GoodsListDto> getAllGoods(
+		@RequestParam(required = false) Long cursor,               // 마지막 조회 항목 ID
+		@RequestParam(required = false) List<Long> categoryIds,    // 카테고리 필터
+		@RequestParam(required = false) String keyword,            // 검색어
+		@RequestParam(defaultValue = "popular") String sortBy      // 정렬 기준 (기본값: 최신순)
+	) {
+		return ApiResponse.success(
+			goodsService.getGoods(cursor, categoryIds, keyword, sortBy)
+		);
+	}
 
 	@GetMapping("/all/goods/{goodsId}")
 	public ApiResponse<GoodsDetailDto> getDetailGood(@PathVariable Long goodsId) {

--- a/src/main/java/com/example/swapit/domain/Goods.java
+++ b/src/main/java/com/example/swapit/domain/Goods.java
@@ -2,6 +2,7 @@ package com.example.swapit.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -20,14 +21,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
 @SQLDelete(sql = "UPDATE goods SET is_deleted = true WHERE goods_id = ?")
@@ -61,21 +62,33 @@ public class Goods extends BaseEntity {
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
-	@Builder.Default
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private GoodsTradeStatus goodsTradeStatus = GoodsTradeStatus.AVAILABLE;
+	private GoodsTradeStatus goodsTradeStatus;
 
 	@Column(columnDefinition = "VARCHAR(100)")
 	private String placeName;
 
-	@Builder.Default
 	@Column(nullable = false)
 	private long viewCount = 0;
 
-	@Builder.Default
 	@OneToMany(mappedBy = "good", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<GoodsImages> goodsImagesList = new ArrayList<>();
+	private List<GoodsImages> goodsImagesList;
+
+	@Builder
+	public Goods(Users user, String title, long price, GoodsQuality quality, Categories category, String content,
+		String placeName, List<GoodsImages> goodsImagesList) {
+		this.user = user;
+		this.title = title;
+		this.price = price;
+		this.quality = quality;
+		this.category = category;
+		this.content = content;
+		this.goodsTradeStatus = GoodsTradeStatus.AVAILABLE; // 기본값 적용
+		this.viewCount = 0;    // 기본값 적용
+		this.placeName = placeName;
+		this.goodsImagesList = Objects.requireNonNullElse(goodsImagesList, new ArrayList<>()); // null이면 초기화.
+	}
 
 	// todo: 사진 api 추가 후, 수정 필요.
 	public void update(GoodsRequestDto request, Categories category) {

--- a/src/main/java/com/example/swapit/domain/GoodsImages.java
+++ b/src/main/java/com/example/swapit/domain/GoodsImages.java
@@ -1,0 +1,36 @@
+package com.example.swapit.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class GoodsImages {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "goods_images_id")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "goods_id", nullable = false)
+	private Goods good;
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	private String imageUrl;
+
+	@Column(columnDefinition = "VARCHAR(255)", nullable = false)
+	private String mimeType;
+}

--- a/src/main/java/com/example/swapit/domain/dto/GoodsListDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/GoodsListDto.java
@@ -1,0 +1,15 @@
+package com.example.swapit.domain.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GoodsListDto {
+	private List<GoodsDto> goodsList;
+	private boolean hasNext;
+	private Long lastCursorId;
+	private int size;
+}

--- a/src/main/java/com/example/swapit/repository/CustomGoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/CustomGoodsRepository.java
@@ -1,0 +1,15 @@
+package com.example.swapit.repository;
+
+import java.util.List;
+
+import com.example.swapit.domain.Goods;
+
+public interface CustomGoodsRepository {
+	List<Goods> findGoodsByCursor(
+		Long cursor,                // 마지막으로 조회된 항목 ID
+		List<Long> categoryIds,     // 카테고리 ID 리스트
+		String keyword,             // 검색어
+		String sortBy,              // 정렬 기준
+		int size                    // 가져올 데이터 수
+	);
+}

--- a/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.QGoods;
@@ -33,10 +34,22 @@ public class CustomGoodsRepositoryImpl implements CustomGoodsRepository {
 			? null
 			: qGoods.category.id.in(categoryIds);
 
+		// 정렬 기준 설정을 Map으로 관리
+		Map<String, OrderSpecifier<?>> orderByMap = Map.of(
+			"popular", qGoods.viewCount.desc(),
+			"recent", qGoods.createdAt.desc(),
+			"priceHigh", qGoods.price.desc(),
+			"priceLow", qGoods.price.asc()
+		);
+
+		// 정렬 기준이 없을 경우, 기본값 설정
+		String safeSortby = (sortBy == null) ? "popular" : sortBy;
+		OrderSpecifier<?> orderSpecifier = orderByMap.get(safeSortby);
+
 		// 동적 조건: 커서 (커서 기준 다음 거부터 조회)
 		BooleanExpression cursorCondition = (cursor == null)
 			? null // 처음 요청일 경우 커서 조건 제외
-			: switch (sortBy) {
+			: switch (safeSortby) {
 			case "popular" -> qGoods.viewCount.lt(cursor); // 인기순: 조회수 기준 커서
 			case "recent" -> qGoods.createdAt.lt(
 				LocalDateTime.ofInstant(Instant.ofEpochMilli(cursor), ZoneId.systemDefault())
@@ -46,15 +59,7 @@ public class CustomGoodsRepositoryImpl implements CustomGoodsRepository {
 			default -> qGoods.id.gt(cursor); // 기본값: 인기순
 		};
 
-		// 정렬 조건
-		OrderSpecifier<?> orderSpecifier = switch (sortBy) {
-			case "popular" -> qGoods.viewCount.desc(); // 인기순
-			case "recent" -> qGoods.createdAt.desc();  // 최신순
-			case "priceHigh" -> qGoods.price.desc();   // 가격 높은 순
-			case "priceLow" -> qGoods.price.asc();     // 가격 낮은 순
-			default -> qGoods.createdAt.desc();        // 기본값: 최신순
-		};
-
+		// todo : 나중에 쿼리 최적화 시, size+1개 가져오는 거랑 count() 서브쿼리로 다음 데이터가 있는지 확인하는 거 최적화 필요.
 		// 쿼리 실행
 		return queryFactory.selectFrom(qGoods)
 			.where(cursorCondition, keywordCondition, categoryCondition)

--- a/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.example.swapit.repository;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.QGoods;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomGoodsRepositoryImpl implements CustomGoodsRepository {
+
+	private final JPAQueryFactory queryFactory;
+	private final QGoods qGoods = QGoods.goods;
+
+	@Override
+	public List<Goods> findGoodsByCursor(
+		Long cursor, List<Long> categoryIds, String keyword, String sortBy, int size
+	) {
+		// 동적 조건: 검색어 (제목 검색만 가능)
+		BooleanExpression keywordCondition = (keyword == null || keyword.isEmpty())
+			? null
+			: qGoods.title.containsIgnoreCase(keyword);
+
+		// 동적 조건: 카테고리
+		BooleanExpression categoryCondition = (categoryIds == null || categoryIds.isEmpty())
+			? null
+			: qGoods.category.id.in(categoryIds);
+
+		// 동적 조건: 커서 (커서 기준 다음 거부터 조회)
+		BooleanExpression cursorCondition = (cursor == null)
+			? null // 처음 요청일 경우 커서 조건 제외
+			: switch (sortBy) {
+			case "popular" -> qGoods.viewCount.lt(cursor); // 인기순: 조회수 기준 커서
+			case "recent" -> qGoods.createdAt.lt(
+				LocalDateTime.ofInstant(Instant.ofEpochMilli(cursor), ZoneId.systemDefault())
+			); // 최신순
+			case "priceHigh" -> qGoods.price.lt(cursor);
+			case "priceLow" -> qGoods.price.gt(cursor);
+			default -> qGoods.id.gt(cursor); // 기본값: 인기순
+		};
+
+		// 정렬 조건
+		OrderSpecifier<?> orderSpecifier = switch (sortBy) {
+			case "popular" -> qGoods.viewCount.desc(); // 인기순
+			case "recent" -> qGoods.createdAt.desc();  // 최신순
+			case "priceHigh" -> qGoods.price.desc();   // 가격 높은 순
+			case "priceLow" -> qGoods.price.asc();     // 가격 낮은 순
+			default -> qGoods.createdAt.desc();        // 기본값: 최신순
+		};
+
+		// 쿼리 실행
+		return queryFactory.selectFrom(qGoods)
+			.where(cursorCondition, keywordCondition, categoryCondition)
+			.orderBy(orderSpecifier)
+			.limit(size + 1) // size + 1로 다음 페이지 여부 확인
+			.fetch();
+	}
+}

--- a/src/main/java/com/example/swapit/repository/GoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/GoodsRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.swapit.domain.Goods;
 
-public interface GoodsRepository extends JpaRepository<Goods, Long> {
+public interface GoodsRepository extends JpaRepository<Goods, Long>, CustomGoodsRepository {
 }

--- a/src/main/java/com/example/swapit/service/GoodsService.java
+++ b/src/main/java/com/example/swapit/service/GoodsService.java
@@ -1,5 +1,7 @@
 package com.example.swapit.service;
 
+import java.util.List;
+
 import com.example.swapit.domain.dto.GoodsDetailDto;
 import com.example.swapit.domain.dto.GoodsListDto;
 import com.example.swapit.domain.dto.GoodsRequestDto;
@@ -7,7 +9,7 @@ import com.example.swapit.domain.dto.GoodsRequestDto;
 public interface GoodsService {
 
 	// 물건 조회
-	GoodsListDto getGoods();
+	GoodsListDto getGoods(Long cursor, List<Long> categoryIds, String keyword, String sortBy);
 
 	GoodsDetailDto getGoodDetail(Long goodsId);
 

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.swapit.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.example.swapit.common.exception.CustomException;
@@ -8,6 +10,7 @@ import com.example.swapit.domain.Categories;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.GoodsDetailDto;
+import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.domain.dto.GoodsListDto;
 import com.example.swapit.domain.dto.GoodsRequestDto;
 import com.example.swapit.repository.CategoriesRepository;
@@ -28,9 +31,29 @@ public class GoodsServiceImpl implements GoodsService {
 	private final UsersRepository usersRepository;
 	private final CategoriesRepository categoriesRepository;
 
+	private final int size = 30;
+
 	@Override
-	public GoodsListDto getGoods() {
-		return null;
+	public GoodsListDto getGoods(
+		Long cursor, List<Long> categoryIds, String keyword, String sortBy
+	) {
+
+		// Goods 조회
+		List<Goods> goodsList = goodsRepository.findGoodsByCursor(
+			cursor, categoryIds, keyword, sortBy, size);
+
+		boolean hasNext = goodsList.size() > size;
+
+		// 요청한 크기만큼 데이터 제한
+		List<Goods> paginateGoods = hasNext ? goodsList.subList(0, size) : goodsList;
+
+		List<GoodsDto> goodsDtoList = paginateGoods.stream()
+			.map(GoodsDto::of)
+			.toList();
+
+		Long lastCursorId = paginateGoods.isEmpty() ? null : paginateGoods.get(paginateGoods.size() - 1).getId();
+
+		return new GoodsListDto(goodsDtoList, hasNext, lastCursorId, size);
 	}
 
 	@Override

--- a/src/test/java/com/example/swapit/repository/GoodsRepositoryTest.java
+++ b/src/test/java/com/example/swapit/repository/GoodsRepositoryTest.java
@@ -1,0 +1,258 @@
+package com.example.swapit.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.example.swapit.config.QueryDslConfig;
+import com.example.swapit.domain.Categories;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.GoodsQuality;
+import com.example.swapit.domain.Users;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class GoodsRepositoryTest {
+
+	@Autowired
+	private GoodsRepository goodsRepository;
+
+	@Autowired
+	private UsersRepository usersRepository;
+
+	@Autowired
+	private CategoriesRepository categoriesRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	private Users testUser;
+	private Categories testCategory;
+	private Categories testCategory2;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트용 Users, Categories 저장
+		testUser = Users.builder()
+			.nickname("testUser")
+			.profileImageUrl("/images/testUser")
+			.email("test@gmail.com")
+			.loginInfo("google")
+			.build();
+		testCategory = Categories.builder().name("ELECTRONICS").build();
+		testCategory2 = Categories.builder().name("APPLIANCES").build();
+
+		usersRepository.save(testUser);
+		categoriesRepository.save(testCategory);
+		categoriesRepository.save(testCategory2);
+
+		// Goods 저장
+		goodsRepository.saveAll(List.of(
+			// 전자기기 : ELECTRONICS : 5개
+			Goods.builder().user(testUser).title("아이폰 14").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("아이폰 15").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("아이폰 16").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("아이폰 16 Pro").price(10_000L).quality(GoodsQuality.NEW)
+				.category(testCategory).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("갤럭시 S25").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory).content("싸게 드려요! 교환주세요!").build(),
+			// 가전제품 : APPLIANCES : 3개
+			Goods.builder().user(testUser).title("전자레인지").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory2).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("오븐").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory2).content("싸게 드려요! 교환주세요!").build(),
+			Goods.builder().user(testUser).title("세탁기").price(1000L).quality(GoodsQuality.NEW)
+				.category(testCategory2).content("싸게 드려요! 교환주세요!").build()
+		));
+
+		em.flush(); // db 반영
+		em.clear(); // 영속성 컨텍스트 초기화
+	}
+
+	@Test
+	@DisplayName("기본 정렬, 물건 목록 조회")
+	void findGoods() {
+		// given
+		// 마지막 커서 id 없음
+		int size = 2; // 조회 할 데이터 개수
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			null, null, null, null, size
+		);
+
+		// then
+		assertEquals(size + 1, results.size());
+
+		for (Goods good : results) {
+			System.out.println("Goods ID: " + good.getId() + "  | Title: " + good.getTitle());
+		}
+	}
+
+	@Test
+	@DisplayName("마지막 커서 기반, 최신순 물건 목록 조회")
+	void findGoodsByCursor_sortByRecent() {
+		// given
+		Goods cursorGoods = goodsRepository.findAll()
+			.stream()
+			.max(Comparator.comparing(Goods::getCreatedAt)) // 최신 데이터 찾기
+			.orElseThrow();
+		Long cursor = cursorGoods.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+		// cursor를 createdAt 값으로 설정
+
+		List<Long> categoryIds = List.of(testCategory.getId());
+		String sortBy = "recent";
+		int size = 2; // 조회 할 데이터 개수
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			cursor, categoryIds, null, sortBy, size
+		);
+
+		// then
+		for (Goods good : results) {
+			System.out.println("Good Title: " + good.getTitle() + " | Good Category ID: " + good.getCategory().getId());
+		}
+
+		assertEquals(size + 1, results.size());
+		for (Goods good : results) {
+			assertTrue(good.getCreatedAt().isBefore(cursorGoods.getCreatedAt()),
+				"Good ID: " + good.getId() + " 의 createdAt이 커서보다 오래된 데이터여야 합니다.");
+		}
+	}
+
+	@Test
+	@DisplayName("마지막 커서 기반, 가격 높은 순 물건 목록 조회")
+	void findGoodsByCursor_sortByPriceHigh() {
+		// given
+		Goods cursorGoods = goodsRepository.findAll()
+			.stream()
+			.max(Comparator.comparing(Goods::getPrice)) // 가장 높은 가격 데이터 찾기.
+			.orElseThrow();
+		Long cursor = cursorGoods.getPrice();
+
+		List<Long> categoryIds = List.of(testCategory.getId());
+		String sortBy = "priceHigh";
+		int size = 2; // 조회 할 데이터 개수
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			cursor, categoryIds, null, sortBy, size
+		);
+
+		// then
+		for (Goods good : results) {
+			System.out.println("Good Title: " + good.getTitle() + " | Good Category ID: " + good.getCategory().getId());
+		}
+
+		assertEquals(size + 1, results.size());
+		for (Goods good : results) {
+			assertTrue(good.getPrice() < cursor,
+				"Good ID: " + good.getId() + " 의 가격이 cursor보다 낮은 가격이여야 합니다.");
+		}
+	}
+
+	@Test
+	@DisplayName("특정 카테고리로 필터링된 물건 목록")
+	void findBoodsByCategory() {
+		// given
+		List<Long> categoryIds = List.of(testCategory2.getId()); // 가전제품
+		int size = 2;
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			null, categoryIds, null, null, size
+		);
+
+		// then
+		for (Goods good : results) {
+			System.out.println("Good Title: " + good.getTitle() + " | Good Category ID: " + good.getCategory().getId());
+		}
+		assertFalse(results.isEmpty(), "조회 된 목록이 비어있지 않아야 합니다.");
+		assertTrue(results.stream().allMatch(c -> c.getCategory().getId().equals(testCategory2.getId())),
+			"모든 결과값의 카테고리가 " + testCategory2.getId() + " 이(가) 아닙니다.");
+	}
+
+	@Test
+	@DisplayName("최신순으로 정렬된 물건 목록 조회")
+	void findGoods_sortedByRecent() {
+		// given
+		// 마지막 커서 id 없음
+		List<Long> categoryIds = List.of(testCategory2.getId());
+		String sortBy = "recent";
+		int size = 2; // 조회 할 데이터 개수
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			null, categoryIds, null, sortBy, size
+		);
+
+		// then
+		assertEquals(size + 1, results.size());
+
+		// createdAt이 내림차순인지 확인
+		for (int i = 0; i < results.size() - 1; i++) {
+			assertTrue(
+				results.get(i).getCreatedAt().isAfter(results.get(i + 1).getCreatedAt()) ||
+					results.get(i).getCreatedAt().isEqual(results.get(i + 1).getCreatedAt())
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("가격 높은 순으로 정렬된 물건 목록 조회")
+	void findGoods_sortedByHighPrice() {
+		// given
+		List<Long> categoryIds = List.of(testCategory.getId());
+		String sortBy = "priceHigh";
+		int size = 2;
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			null, categoryIds, null, sortBy, size
+		);
+
+		// then
+		assertEquals(size + 1, results.size()); // ✅ 개수 검증
+
+		// ✅ 가격 높은 순 검증
+		for (int i = 0; i < results.size() - 1; i++) {
+			assertTrue(results.get(i).getPrice() >= results.get(i + 1).getPrice());
+		}
+	}
+
+	@Test
+	@DisplayName("검색어 필터링이 적용된 물건 목록 조회")
+	void findGoodsByKeyword() {
+		// given
+		List<Long> categoryIds = List.of(testCategory.getId());
+		String keyword = "갤럭시";
+		int size = 2; // 조회 할 데이터 개수
+
+		// when
+		List<Goods> results = goodsRepository.findGoodsByCursor(
+			null, categoryIds, keyword, null, size
+		);
+
+		// then
+		assertFalse(results.isEmpty()); // 갤럭시 매물이 잇어야 함.
+		assertTrue(results.stream().allMatch(t -> t.getTitle().contains(keyword))); // 키워드 포함 확인.
+	}
+}

--- a/src/test/java/com/example/swapit/service/GoodServiceTest.java
+++ b/src/test/java/com/example/swapit/service/GoodServiceTest.java
@@ -57,7 +57,6 @@ class GoodServiceTest {
 			.build();
 
 		testGood = Goods.builder()
-			.id(1L)
 			.user(testUser)
 			.title("test 물건")
 			.price(1000L)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#2 

## 📝 작업 내용
- QueryDSL 도입
- CustomGoodsRepository를 분리해서, QueryDSL의 동적쿼리를 사용한 물건 목록 리스트 조회 함수 생성
- GoodsImages 엔티티 생성
- GoodsService, GoodsController에 물건 목록 조회 적용

### 수정사항
- Goods 클래스의 @Builder를 `전체 엔티티` -> 필수 필드만 주입받도록 생성자 분리 + @Builder 적용
- RestController 클래스의 api 경로 수정

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> Repository test 코드를 입력햇음에도 불구하고 sonarqube에서는 테스트 커버리지가 없는 걸로 나오는 게 의문이긴 한데, 적용이 늦는건지는 모르겠습니다. 
> 그리고 Controller 테스트코드랑 service 테스트 코드는 따로 브랜치를 파서 올리겠습니다.  repository 만 해도 많아져서 pr 단위를 나눠 올립니다!
