### PR TITLE
[ci] application.yaml을 profile로 관리하도록 수정

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+
+  logging.level:
+    org.hibernate.SQL: debug

--- a/src/main/resources/application-prd.yaml
+++ b/src/main/resources/application-prd.yaml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create    # erd 안정화되면 "validate"로 변경 예정.
+    open-in-view: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,22 +1,10 @@
 spring:
   application:
     name: swapit
-  config:
-    import: optional:file:.env[.properties]
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-  jpa:
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-    open-in-view: false
+  profiles:
+    active:
+      - prd   # 로컬에서는 dev로 변경해서 사용.
 
   security:
     oauth2:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#14 

## 📝 작업 내용
로컬 환경에서 사용하는 db가 달라서 각자 사용하는 db를 application-dev.yaml에 저장해서 사용 권장

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
> 1. application.yaml이 너무 길어지는 것을 방지
> 2. 개발할 때 사용하는 DB가 달라서 해당 부분을 분리
> 3. 배포 환경은 로그 출력 최소화
> 
> 위의 이유로 yaml 파일을 분리하여 profile로 만들어서 주입하는 식으로 변경하였습니다.
