### PR TITLE
[feature] 헤더의 액세스 토큰 검증하는 필터 추가

### DIFF
--- a/src/main/java/com/example/swapit/config/security/CustomUserDetails.java
+++ b/src/main/java/com/example/swapit/config/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.example.swapit.config.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.example.swapit.domain.Users;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+	private final Users user;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority(user.getRole()));
+	}
+
+	@Override
+	public String getPassword() {
+		return "";
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	public Users getUser() {
+		return user;
+	}
+}

--- a/src/main/java/com/example/swapit/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/swapit/config/security/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.example.swapit.config.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.domain.Users;
+import com.example.swapit.repository.UsersRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UsersRepository usersRepository;
+
+	public CustomUserDetailsService(UsersRepository usersRepository) {
+		this.usersRepository = usersRepository;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		Users user = usersRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		return new CustomUserDetails(user);
+	}
+}

--- a/src/main/java/com/example/swapit/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/swapit/config/security/SecurityConfig.java
@@ -6,6 +6,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.example.swapit.config.security.jwt.JwtAuthenticationFilter;
+import com.example.swapit.config.security.jwt.JwtProvider;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+	private final JwtProvider jwtProvider;
+	private final CustomUserDetailsService userDetailsService;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,6 +32,8 @@ public class SecurityConfig {
 				.anyRequest()
 				.authenticated() // 그 외 요청은 인증 필요
 			)
+			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userDetailsService),
+				UsernamePasswordAuthenticationFilter.class)
 			.exceptionHandling((exception) -> exception.authenticationEntryPoint(
 				(request, response, authException) -> response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
 					"Unauthorized")));

--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -28,7 +28,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/user/auth/refresh",
 		"/api/all/auth/login/google",
 		"/api/all/auth/login/kakao",
-		"/api/user/auth/logout"
+		"/api/user/auth/logout",
+		"/api/all/sample"
 	);
 
 	@Override

--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.example.swapit.config.security.jwt;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.example.swapit.config.security.CustomUserDetailsService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+	private final CustomUserDetailsService userDetailsService;
+
+	private static final List<String> EXCLUDE_URLS = Arrays.asList(
+		"/api/user/auth/refresh",
+		"/api/all/auth/login/google",
+		"/api/all/auth/login/kakao",
+		"/api/user/auth/logout"
+	);
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return EXCLUDE_URLS.stream()
+			.anyMatch(exclude -> request.getServletPath().equals(exclude));
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		String header = request.getHeader("Authorization");
+		if (header != null && header.startsWith("Bearer ")) {
+			String token = header.substring(7);
+			if (jwtProvider.validateToken(token)) {
+				String username = jwtProvider.getEmailFromToken(token);
+				UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+}
+

--- a/src/main/java/com/example/swapit/controller/UserController.java
+++ b/src/main/java/com/example/swapit/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.example.swapit.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.swapit.config.security.CustomUserDetails;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.UserResponseDTO;
+
+@Controller
+public class UserController {
+	// 사용자 정보 가져오는 임시 코드
+	@GetMapping("api/user/me")
+	public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		if (customUserDetails == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 정보가 없습니다.");
+		}
+		Users user = customUserDetails.getUser();
+		UserResponseDTO userResponseDTO = UserResponseDTO.builder()
+			.nickname(user.getNickname())
+			.email(user.getEmail())
+			.profileImgUrl(user.getProfileImageUrl())
+			.loginInfo(user.getLoginInfo())
+			.build();
+		return ResponseEntity.ok(userResponseDTO);
+	}
+}

--- a/src/main/java/com/example/swapit/domain/Users.java
+++ b/src/main/java/com/example/swapit/domain/Users.java
@@ -6,7 +6,6 @@ import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -45,10 +44,10 @@ public class Users {
 	private String role;
 
 	@Builder.Default
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Goods> goodsList = new ArrayList<>();
 
 	@Builder.Default
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Notifications> notificationsList = new ArrayList<>();
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

없습니다~

## 📝 작업 내용

- 헤더의 액세스 토큰 검증하는 필터 추가
- 사용자 정보 가져오는 임시 코드 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항

사용자 정보 가져오는 부분은 임시 코드입니다. api 호출할 때 헤더에 Bearer <토큰> 설정하면 됩니다!
