### PR TITLE
[fix] 엔티티 id 자동증가 적용되도록 자동생성전략 설정

### DIFF
--- a/src/main/java/com/example/swapit/domain/Notifications.java
+++ b/src/main/java/com/example/swapit/domain/Notifications.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class Notifications extends BaseEntity {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "notifications_id")
 	private Long id;
 

--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class Trades extends BaseEntity {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "trades_id")
 	private Long id;
 

--- a/src/main/resources/application-prd.yaml
+++ b/src/main/resources/application-prd.yaml
@@ -7,5 +7,5 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create    # erd 안정화되면 "validate"로 변경 예정.
+      ddl-auto: update    # erd 안정화되면 "validate"로 변경 예정.
     open-in-view: false

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -92,7 +92,7 @@ class GoodsControllerTest {
 		// given
 		GoodsDetailDto mockGoodsDetail = new GoodsDetailDto(
 			1L,
-			new UserProfileDto(1L, "testUser", 4.8), // 예제 사용자 데이터
+			new UserProfileDto(1L, "testUser", 4.8),
 			"전자기기",
 			"아이폰 15",
 			1200L,
@@ -109,7 +109,7 @@ class GoodsControllerTest {
 		given(goodsService.getGoodDetail(1L)).willReturn(mockGoodsDetail);
 
 		mockMvc.perform(get("/api/all/goods/{goodsId}", 1L))
-			.andDo(print()) // ✅ 실제 JSON 응답 확인
+			.andDo(print())
 			.andExpect(status().isOk());
 
 		// when & then


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#20 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- Trades, Notifications 엔티티의 id값 자동생성전략 적용
- prod 운영환경에서 데이터가 유지되도록 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
> 배포된 환경에 적용할 부분만 빠르게 적용하겠습니다!
> 그리고 이전에 커밋만 하고 push 보내지 못한 주석 제거  commit을 함께 pr 합니다.
