### PR TITLE
[fix] cursor 이후 데이터 조회 시, 현재 데이터 포함하는 에러 해결

### DIFF
--- a/src/main/java/com/example/swapit/common/api/ErrorResponse.java
+++ b/src/main/java/com/example/swapit/common/api/ErrorResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @JsonPropertyOrder({"status", "errorCode", "message"})
 public class ErrorResponse {
-	private int status;
-	private String errorCode;
-	private String message;
+	private final int status;
+	private final String errorCode;
+	private final String message;
 }

--- a/src/main/java/com/example/swapit/common/api/ErrorResponse.java
+++ b/src/main/java/com/example/swapit/common/api/ErrorResponse.java
@@ -3,11 +3,13 @@ package com.example.swapit.common.api;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"status", "errorCode", "message"})
 public class ErrorResponse {
-	private final int status;
-	private final String errorCode;
-	private final String message;
+	private int status;
+	private String errorCode;
+	private String message;
 }

--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
 	// goods error
 	GOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "물건을 찾을 수 없습니다."),
 	MISSING_CURSOR_CREATEDAT(HttpStatus.BAD_REQUEST, "최신순에는 createdAt 필드값 입력이 필수입니다."),
-	MISSING_CURSOR_VALUE(HttpStatus.BAD_REQUEST, "정렬 조건에 맞는 필드 값이 필요합니다."),
+	MISSING_CURSOR_VALUE(HttpStatus.BAD_REQUEST, "정렬 조건에 맞는 cursor 필드 값이 필요합니다."),
+	INVALID_SORT_BY(HttpStatus.BAD_REQUEST, "잘못된 정렬 조건입니다."),
 
 	// categories error
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),

--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -21,8 +21,9 @@ public enum ErrorCode {
 
 	// goods error
 	GOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "물건을 찾을 수 없습니다."),
+	MISSING_CURSOR_CREATEDAT(HttpStatus.BAD_REQUEST, "최신순에는 createdAt 필드값 입력이 필수입니다."),
 	MISSING_CURSOR_VALUE(HttpStatus.BAD_REQUEST, "정렬 조건에 맞는 필드 값이 필요합니다."),
-	
+
 	// categories error
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
 

--- a/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
@@ -7,11 +7,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.example.swapit.common.api.ErrorResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.error("유효하지 않은 매개변수 Exception 발생! errorMessage : {}", e.getMessage());
 		return ResponseEntity
 			.status(e.getStatusCode())
 			.body(new ErrorResponse(
@@ -23,12 +27,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+		log.error("Custom Exception 발생! errorCode : {}, errorMessage : {}", e.getErrorCode(), e.getMessage());
 		return ResponseEntity
 			.status(e.getStatusCode())
 			.body(new ErrorResponse(
 				e.getStatusCode(),
 				e.getErrorCode().name(),
-				e.getMessage()
-			));
+				e.getMessage()));
 	}
 }

--- a/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-		log.error("Custom Exception 발생! errorCode : {}, errorMessage : {}", e.getErrorCode(), e.getMessage());
+		log.error("[Custom Exception 발생!] errorCode : {}, errorMessage : {}", e.getErrorCode(), e.getMessage());
 		return ResponseEntity
 			.status(e.getStatusCode())
 			.body(new ErrorResponse(

--- a/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/swapit/common/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		log.error("유효하지 않은 매개변수 Exception 발생! errorMessage : {}", e.getMessage());
+		log.error("[유효하지 않은 매개변수 Exception 발생] errorMessage : {}", e.getMessage());
 		return ResponseEntity
 			.status(e.getStatusCode())
 			.body(new ErrorResponse(
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-		log.error("[Custom Exception 발생!] errorCode : {}, errorMessage : {}", e.getErrorCode(), e.getMessage());
+		log.error("[Custom Exception 발생] errorCode : {}, errorMessage : {}", e.getErrorCode(), e.getMessage());
 		return ResponseEntity
 			.status(e.getStatusCode())
 			.body(new ErrorResponse(

--- a/src/main/java/com/example/swapit/controller/GoodsController.java
+++ b/src/main/java/com/example/swapit/controller/GoodsController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.domain.dto.GoodsDetailDto;
 import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.domain.dto.GoodsListDto;
@@ -22,7 +24,9 @@ import com.example.swapit.service.GoodsService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -48,6 +52,22 @@ public class GoodsController {
 		@RequestParam(required = false) String keyword,                    // 검색어
 		@RequestParam(defaultValue = "popular") String sortBy            // 정렬 기준 (기본값: 최신순)
 	) {
+		log.debug("cursorValue : {}, cursorId : {}, createdAt : {}, categoryIds : {}, keyword : {}, sortBy : {}",
+			cursorValue, cursorId, createdAt, categoryIds, keyword, sortBy);
+
+		// 허용된 sortBy 값 체크
+		List<String> allowedSortValues = List.of("popular", "recent", "priceHigh", "priceLow");
+		if (sortBy != null && !allowedSortValues.contains(sortBy)) {
+			throw new CustomException(ErrorCode.INVALID_SORT_BY);
+		}
+		// 필수 요청 값 검증
+		if ("recent".equals(sortBy) && cursorId != null && createdAt == null) {
+			throw new CustomException(ErrorCode.MISSING_CURSOR_CREATEDAT);
+		}
+		if (cursorId != null && cursorValue == null) {
+			throw new CustomException(ErrorCode.MISSING_CURSOR_VALUE);
+		}
+
 		return ApiResponse.success(
 			goodsService.getGoods(cursorValue, cursorId, createdAt, categoryIds, keyword, sortBy)
 		);

--- a/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/CustomGoodsRepositoryImpl.java
@@ -57,36 +57,40 @@ public class CustomGoodsRepositoryImpl implements CustomGoodsRepository {
 		OrderSpecifier<?> orderSpecifier = orderByMap.get(safeSortby);
 
 		// 동적 조건: 커서 기반 페이지네이션 (cursorFieldValue + goodsId)
-		BooleanExpression cursorCondition = (cursorValue == null || cursorId == null)
+		BooleanExpression cursorCondition = (cursorId == null)
 			? null // 처음 요청일 경우 커서 조건 제외
 			: switch (safeSortby) {
 			// 인기순 (조회수 내림차순)
 			// WHERE view_count < cursorFieldValue
 			// OR (view_count = cursorFieldValue AND goods_id > goodsId)
-			case "popular" -> qGoods.viewCount.lt(cursorValue)
+			case "popular" -> (cursorValue == null) ? null
+				: qGoods.viewCount.lt(cursorValue)
 				.or(qGoods.viewCount.eq(cursorValue).and(qGoods.id.gt(cursorId)));
 
 			// 최신순 (생성일 내림차순)
 			// WHERE created_at < cursorCreatedAt
-			// OR (created_at = cursorCreatedAt AND goods_id > cursorId)
-			case "recent" -> (createdAt == null || cursorId == null) ? null
-				: qGoods.createdAt.lt(createdAt)
-				.or(qGoods.createdAt.eq(createdAt)).and(qGoods.id.gt(cursorId));
+			// OR (created_at = cursorCreatedAt AND goods_id < cursorId)
+			case "recent" -> (createdAt == null) ? null
+				: qGoods.createdAt.lt(createdAt) // 현재 커서 날짜 이전 데이터만 가져옴
+				.or(qGoods.createdAt.eq(createdAt).and(qGoods.id.lt(cursorId))); // 같은 날짜면 id가 작은 것만 가져옴
 
 			// 높은 가격순 (가격 내림차순)
 			// WHERE price < cursorFieldValue
 			// OR (price = cursorFieldValue AND goods_id > goodsId)
-			case "priceHigh" -> qGoods.price.lt(cursorValue)
+			case "priceHigh" -> (cursorValue == null) ? null
+				: qGoods.price.lt(cursorValue)
 				.or(qGoods.price.eq(cursorValue).and(qGoods.id.gt(cursorId)));
 
 			// 낮은 가격순 (가격 오름차순)
 			// WHERE price > cursorFieldValue
 			// OR (price = cursorFieldValue AND goods_id > goodsId)
-			case "priceLow" -> qGoods.price.gt(cursorValue)
-				.or(qGoods.price.eq(cursorValue).and(qGoods.id.gt(cursorId)));
+			case "priceLow" -> (cursorValue == null) ? null
+				: qGoods.price.gt(cursorValue) // 가격이 cursorValue 초과 (>)
+				.or(qGoods.price.eq(cursorValue).and(qGoods.id.gt(cursorId))); // 같은 가격이면 id가 cursorId보다 큰 것 (>)
 
 			// 기본값 : 인기순
-			default -> qGoods.viewCount.lt(cursorValue)
+			default -> (cursorValue == null) ? null
+				: qGoods.viewCount.lt(cursorValue)
 				.or(qGoods.viewCount.eq(cursorValue).and(qGoods.id.gt(cursorId)));
 		};
 

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -37,10 +37,12 @@ public class GoodsServiceImpl implements GoodsService {
 	public GoodsListDto getGoods(
 		Long cursorValue, Long cursorId, LocalDateTime createdAt, List<Long> categoryIds, String keyword, String sortBy
 	) {
-
-		// 최신순으로 정렬하는데, createdAt 필드값이 null이라면 에러.
-		if (sortBy.equals("recent") && createdAt == null) {
-			throw new CustomException(ErrorCode.MISSING_CURSOR_VALUE);
+		log.debug("cursorValue : {}, cursorId : {}, createdAt : {}, categoryIds : {}, keyword : {}, sortBy : {}",
+			cursorValue, cursorId, createdAt, categoryIds, keyword, sortBy);
+		
+		// 최신순으로 정렬하는데, cursor가 있으면 createdAt이 null이면 안됨.
+		if (sortBy.equals("recent") && cursorId != null && createdAt == null) {
+			throw new CustomException(ErrorCode.MISSING_CURSOR_CREATEDAT);
 		}
 
 		// Goods 조회

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -37,14 +37,6 @@ public class GoodsServiceImpl implements GoodsService {
 	public GoodsListDto getGoods(
 		Long cursorValue, Long cursorId, LocalDateTime createdAt, List<Long> categoryIds, String keyword, String sortBy
 	) {
-		log.debug("cursorValue : {}, cursorId : {}, createdAt : {}, categoryIds : {}, keyword : {}, sortBy : {}",
-			cursorValue, cursorId, createdAt, categoryIds, keyword, sortBy);
-		
-		// 최신순으로 정렬하는데, cursor가 있으면 createdAt이 null이면 안됨.
-		if (sortBy.equals("recent") && cursorId != null && createdAt == null) {
-			throw new CustomException(ErrorCode.MISSING_CURSOR_CREATEDAT);
-		}
-
 		// Goods 조회
 		List<Goods> goodsList = goodsRepository.findGoodsByCursor(
 			cursorValue, cursorId, createdAt, categoryIds, keyword, sortBy, size);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#18 
#2 

## 📝 작업 내용
- 에러 발생 시, body에 응답 안보이는 문제 해결 및 log 출력
- 최신순 정렬 +  cursor 이후 데이터 조회 시, 현재 데이터 포함해서 조회하는 오류 해결
- 정렬, 필터 조건 검증을 GoodsController에 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 최최최종 queryDSL 검증... 제발 이제는 이상 없기를..
