### PR TITLE
feat: 거래 요청 시 개수 및 중복 요청 제한 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 env.properties
+generated/
 
 HELP.md
 .gradle

--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -36,7 +36,9 @@ public enum ErrorCode {
 	LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
 
 	// trades error
-	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다.");
+	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
+	DUPLICATE_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "이미 해당 물건에 스왑 요청한 내역이 있습니다."),
+	MAXIMUM_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "가능한 스왑 요청 횟수를 초과하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @SQLDelete(sql = "UPDATE trades SET is_deleted = true WHERE trades_id = ?")
-@Table(name = "trades")
+@Table(name = "trades",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"target_goods_id, requester_id"})
+)
 public class Trades extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.swapit.domain.Trades;
 
 public interface TradesRepository extends JpaRepository<Trades, Long> {
+	long countByTargetGoodsIdAndIsDeletedFalse(Long goodsId);
 }

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.swapit.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import com.example.swapit.common.exception.CustomException;
@@ -28,7 +29,17 @@ public class TradesServiceImpl implements TradesService {
 		Goods targetGoods = goodsRepository.findById(tradesRequestDto.getTargetGoodsId())
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 
-		tradesRepository.save(new Trades(requestedGoods, targetGoods));
+		long count = tradesRepository.countByTargetGoodsIdAndIsDeletedFalse(tradesRequestDto.getTargetGoodsId());
+
+		if (count >= 10) {
+			throw new CustomException(ErrorCode.MAXIMUM_TRADE_REQUEST);
+		}
+
+		try {
+			tradesRepository.save(new Trades(requestedGoods, targetGoods));
+		} catch (DataIntegrityViolationException ex) {
+			throw new CustomException(ErrorCode.DUPLICATE_TRADE_REQUEST);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -19,6 +19,7 @@ public class TradesServiceImpl implements TradesService {
 
 	private final TradesRepository tradesRepository;
 	private final GoodsRepository goodsRepository;
+	public static final int MAX_REQUEST_COUNT = 10;
 
 	@Override
 	public void requestTrade(TradesRequestDto tradesRequestDto) {
@@ -29,7 +30,7 @@ public class TradesServiceImpl implements TradesService {
 
 		long count = tradesRepository.countByTargetGoodsIdAndIsDeletedFalse(tradesRequestDto.getTargetGoodsId());
 
-		if (count >= 10) {
+		if (count >= MAX_REQUEST_COUNT) {
 			throw new CustomException(ErrorCode.MAXIMUM_TRADE_REQUEST);
 		}
 

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -12,9 +12,7 @@ import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.TradesRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TradesServiceImpl implements TradesService {

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.Trades;
 import com.example.swapit.domain.Users;
@@ -67,6 +70,77 @@ public class TradesServiceTest {
 		// Then
 		verify(goodsRepository, times(1)).findById(dto.getRequestedGoodsId());
 		verify(goodsRepository, times(1)).findById(dto.getTargetGoodsId());
+		verify(tradesRepository, times(1)).save(any(Trades.class));
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 요청된 거래가 10개 초과")
+	void requestTradesMaximumFailure() {
+		// Given
+		Users requester = Users.builder()
+			.email("email")
+			.build();
+		Goods requestedGoods = Goods.builder()
+			.user(requester)
+			.build();
+
+		Users target = Users.builder()
+			.email("email")
+			.build();
+		Goods targetGoods = Goods.builder()
+			.user(target)
+			.build();
+
+		dto = new TradesRequestDto(1L, 2L);
+
+		when(goodsRepository.findById(dto.getRequestedGoodsId())).thenReturn(Optional.of(requestedGoods));
+		when(goodsRepository.findById(dto.getTargetGoodsId())).thenReturn(Optional.of(targetGoods));
+		when(tradesRepository.countByTargetGoodsIdAndIsDeletedFalse(dto.getTargetGoodsId())).thenReturn(10L);
+
+		// When
+		CustomException exception = assertThrows(CustomException.class, () -> tradesService.requestTrade(dto));
+		assertEquals(ErrorCode.MAXIMUM_TRADE_REQUEST, exception.getErrorCode());
+
+		// Then
+		verify(goodsRepository, times(1)).findById(dto.getRequestedGoodsId());
+		verify(goodsRepository, times(1)).findById(dto.getTargetGoodsId());
+		verify(tradesRepository, times(1)).countByTargetGoodsIdAndIsDeletedFalse(dto.getTargetGoodsId());
+		verify(tradesRepository, never()).save(any(Trades.class));
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 중복 거래 요청")
+	void requestTradesDuplicateFailure() {
+		// Given
+		Users requester = Users.builder()
+			.email("email")
+			.build();
+		Goods requestedGoods = Goods.builder()
+			.user(requester)
+			.build();
+
+		Users target = Users.builder()
+			.email("email")
+			.build();
+		Goods targetGoods = Goods.builder()
+			.user(target)
+			.build();
+
+		dto = new TradesRequestDto(1L, 2L);
+
+		when(goodsRepository.findById(dto.getRequestedGoodsId())).thenReturn(Optional.of(requestedGoods));
+		when(goodsRepository.findById(dto.getTargetGoodsId())).thenReturn(Optional.of(targetGoods));
+		when(tradesRepository.countByTargetGoodsIdAndIsDeletedFalse(dto.getTargetGoodsId())).thenReturn(5L);
+		doThrow(new DataIntegrityViolationException("Duplicate")).when(tradesRepository).save(any(Trades.class));
+
+		// When
+		CustomException exception = assertThrows(CustomException.class, () -> tradesService.requestTrade(dto));
+		assertEquals(ErrorCode.DUPLICATE_TRADE_REQUEST, exception.getErrorCode());
+
+		// Then
+		verify(goodsRepository, times(1)).findById(dto.getRequestedGoodsId());
+		verify(goodsRepository, times(1)).findById(dto.getTargetGoodsId());
+		verify(tradesRepository, times(1)).countByTargetGoodsIdAndIsDeletedFalse(dto.getTargetGoodsId());
 		verify(tradesRepository, times(1)).save(any(Trades.class));
 	}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#30 

## 📝 작업 내용

- 거래 요청 시 10개까지로 가능 요청 개수 제한
- 같은 물건에 같은 사용자가 중복 거래 요청 시 제한
- 테스트 코드 작성

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

10개까지 개수 제한 테스트는 테스트 코드로만 해봤고 api 테스트는 더미 데이터가 더 쌓이면 해보려고 합니다..!
