### PR TITLE
[feat] 유저 프로필 이미지 변경

### DIFF
--- a/src/main/java/com/example/swapit/controller/UserController.java
+++ b/src/main/java/com/example/swapit/controller/UserController.java
@@ -3,15 +3,25 @@ package com.example.swapit.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.config.security.CustomUserDetails;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.UserResponseDTO;
+import com.example.swapit.service.UsersService;
 
-@Controller
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
 public class UserController {
+
+	private final UsersService usersService;
+
 	// 사용자 정보 가져오는 임시 코드
 	@GetMapping("api/user/me")
 	public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -26,5 +36,11 @@ public class UserController {
 			.loginInfo(user.getLoginInfo())
 			.build();
 		return ResponseEntity.ok(userResponseDTO);
+	}
+
+	@PatchMapping("/api/user/auth/profile/image")
+	public ApiResponse<Void> updateProfileImage(MultipartFile image) {
+		usersService.updateProfileImage(image);
+		return ApiResponse.success();
 	}
 }

--- a/src/main/java/com/example/swapit/domain/Users.java
+++ b/src/main/java/com/example/swapit/domain/Users.java
@@ -50,4 +50,8 @@ public class Users {
 	@Builder.Default
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Notifications> notificationsList = new ArrayList<>();
+
+	public void updateProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
 }

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -31,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
 	private final UsersRepository usersRepository;
 	private final TokensRepository tokensRepository;
 	private final RestTemplate restTemplate;
+	private final AwsS3Service awsS3Service;
 
 	@Override
 	public TokenDTO refresh(String token) {
@@ -74,7 +75,7 @@ public class AuthServiceImpl implements AuthService {
 			return UserResponseDTO.builder()
 				.nickname(user.getNickname())
 				.email(user.getEmail())
-				.profileImgUrl(user.getProfileImageUrl())
+				.profileImgUrl(awsS3Service.generatePreSignedImageUrl(user.getProfileImageUrl()))
 				.loginInfo(user.getLoginInfo())
 				.build();
 		} catch (CustomException ce) {

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -159,8 +159,11 @@ public class GoodsServiceImpl implements GoodsService {
 		Goods good = goodsRepository.findById(goodsId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 
+		// 현재 상품의 이미지 개수를 정확하게 가져오기 위해 Repository에서 직접 조회
+		List<GoodsImages> existingImages = goodsImagesRepository.findByGood(good);
+
 		// 최대 이미지 개수를 초과하는지 검증
-		if (good.getGoodsImagesList().size() + images.size() > MAX_IMAGES) {
+		if (existingImages.size() + images.size() > MAX_IMAGES) {
 			throw new CustomException(ErrorCode.IMAGE_COUNT_EXCEEDED);
 		}
 

--- a/src/main/java/com/example/swapit/service/UsersService.java
+++ b/src/main/java/com/example/swapit/service/UsersService.java
@@ -1,0 +1,7 @@
+package com.example.swapit.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UsersService {
+	void updateProfileImage(MultipartFile file);
+}

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.swapit.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.swapit.domain.Users;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UsersServiceImpl implements UsersService {
+
+	private final CurrentUserService currentUserService;
+	private final AwsS3Service awsS3Service;
+
+	@Override
+	public void updateProfileImage(MultipartFile file) {
+		Users user = currentUserService.getCurrentUser();
+		user.updateProfileImageUrl(awsS3Service.updateUserProfileImage(user, file));
+	}
+}

--- a/src/test/java/com/example/swapit/controller/UserControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/UserControllerTest.java
@@ -1,0 +1,57 @@
+package com.example.swapit.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.swapit.service.UsersService;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+	private MockMvc mockMvc;
+
+	@InjectMocks
+	private UserController userController;
+
+	@Mock
+	private UsersService usersService;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+	}
+
+	@Test
+	@DisplayName("유저 프로필 이미지 업데이트 성공")
+	void updateProfileImage_Success() throws Exception {
+		// GIVEN: Mock MultipartFile 생성
+		MockMultipartFile mockFile = new MockMultipartFile(
+			"image", "profile.jpg", "image/jpeg", new byte[] {1, 2, 3, 4}
+		);
+
+		// WHEN: API 호출
+		mockMvc.perform(multipart(HttpMethod.PATCH, "/api/user/auth/profile/image")
+				.file(mockFile)
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk()) // 200 응답 확인
+			.andExpect(jsonPath("$.success").value(true)); // ApiResponse.success() 검증
+
+		// THEN: Service 메서드 호출 검증
+		verify(usersService, times(1)).updateProfileImage(any(MultipartFile.class));
+	}
+}

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -53,6 +53,9 @@ public class AuthServiceTest {
 	@Mock
 	private RestTemplate restTemplate;
 
+	@Mock
+	private AwsS3Service awsS3Service;
+
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@BeforeEach
@@ -143,11 +146,12 @@ public class AuthServiceTest {
 		// Given
 		String validAccessToken = "valid_access_token";
 		String email = "test@example.com";
+		String imageUrl = "http://presigned-url.com/image.jpg";
 
 		Users user = Users.builder()
 			.nickname("nickname")
 			.email(email)
-			.profileImageUrl("http://example.com/image.jpg")
+			.profileImageUrl(imageUrl)
 			.loginInfo("google")
 			.build();
 
@@ -155,13 +159,16 @@ public class AuthServiceTest {
 		when(jwtProvider.getEmailFromToken(validAccessToken)).thenReturn(email);
 		when(usersRepository.findByEmail(email)).thenReturn(Optional.of(user));
 
+		when(awsS3Service.generatePreSignedImageUrl(user.getProfileImageUrl()))
+			.thenReturn(imageUrl);
+
 		// When
 		UserResponseDTO userResponseDTO = authService.getUserInfo("Bearer " + validAccessToken);
 
 		// Then
 		assertEquals("nickname", userResponseDTO.getNickname());
 		assertEquals(email, userResponseDTO.getEmail());
-		assertEquals("http://example.com/image.jpg", userResponseDTO.getProfileImgUrl());
+		assertEquals(imageUrl, userResponseDTO.getProfileImgUrl());
 		assertEquals("google", userResponseDTO.getLoginInfo());
 
 		verify(jwtProvider, times(1)).validateToken(validAccessToken);

--- a/src/test/java/com/example/swapit/service/GoodsImagesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/GoodsImagesServiceTest.java
@@ -1,0 +1,199 @@
+package com.example.swapit.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.domain.Categories;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.GoodsImages;
+import com.example.swapit.domain.GoodsQuality;
+import com.example.swapit.domain.Users;
+import com.example.swapit.repository.GoodsImagesRepository;
+import com.example.swapit.repository.GoodsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GoodsImagesServiceTest {
+
+	@InjectMocks
+	private GoodsServiceImpl goodsService;
+
+	@Mock
+	private GoodsRepository goodsRepository;
+
+	@Mock
+	private GoodsImagesRepository goodsImagesRepository;
+
+	@Mock
+	private AwsS3Service awsS3Service;
+
+	private static final int MAX_IMAGES = 10;
+
+	private Goods testGood;
+	private Users testUser;
+	private Categories testCategory;
+
+	@BeforeEach
+	void setUp() {
+		testUser = Users.builder()
+			.usersId(1L)
+			.nickname("testUser")
+			.profileImageUrl("/images/testUser")
+			.email("test@gmail.com")
+			.loginInfo("google")
+			.role("ROLE_USER")
+			.build();
+
+		testCategory = Categories.builder()
+			.id(1L)
+			.name("ELECTRONICS")
+			.build();
+
+		testGood = Goods.builder()
+			.user(testUser)
+			.title("test 물건")
+			.price(1000L)
+			.quality(GoodsQuality.NEW)
+			.category(testCategory)
+			.content("싸게 드려요! 교환주세요!")
+			.build();
+	}
+
+	@Test
+	@DisplayName("물건 사진 업로드 성공")
+	void uploadGoodImages_Success() {
+		// GIVEN
+		List<MultipartFile> mockImages = List.of(
+			new MockMultipartFile("file1", "image1.jpg", "image/jpeg", new byte[] {1, 2, 3}),
+			new MockMultipartFile("file2", "image2.jpg", "image/jpeg", new byte[] {4, 5, 6})
+		);
+
+		List<Pair<String, String>> uploadedImages = List.of(
+			Pair.of("s3-key-1", "image/jpeg"),
+			Pair.of("s3-key-2", "image/jpeg")
+		);
+
+		when(goodsRepository.findById(1L)).thenReturn(Optional.of(testGood));
+		when(awsS3Service.uploadFiles(any(Goods.class), anyList())).thenReturn(uploadedImages);
+
+		// WHEN: 상품 이미지 업로드 수행
+		goodsService.uploadGoodImages(1L, mockImages);
+
+		// THEN: 업로드된 이미지가 저장되었는지 검증
+		verify(goodsRepository, times(1)).findById(1L);
+		verify(awsS3Service, times(1)).uploadFiles(testGood, mockImages);
+		verify(goodsImagesRepository, times(2)).save(any(GoodsImages.class));
+	}
+
+	@Test
+	@DisplayName("최대 이미지 개수를 초과하는 이미지 업로드 요청 실패")
+	void uploadGoodImages_ThrowsException_WhenImageCountExceedsLimit() {
+		// GIVEN: 기존에 MAX_IMAGES 개수만큼 존재하는 상품 이미지 리스트
+		List<GoodsImages> existingImages = new ArrayList<>();
+		for (int i = 0; i < MAX_IMAGES; i++) {
+			existingImages.add(
+				GoodsImages.builder()
+					.good(testGood)
+					.s3Key("s3-key-" + i)
+					.contentType("content-type")
+					.build());
+		}
+
+		// Mock 객체를 사용하여 `getId()` 값을 설정
+		Goods spyGood = spy(testGood); // `testGood`을 spy로 감싸서 ID를 설정 가능하도록 만듦
+		when(spyGood.getId()).thenReturn(1L); // getId()가 1L을 반환하도록 설정
+
+		// Mock 설정: 상품에 대한 이미지 리스트 반환
+		when(goodsImagesRepository.findByGood(spyGood)).thenReturn(existingImages);
+		when(goodsRepository.findById(anyLong())).thenReturn(Optional.of(spyGood)); // 모든 ID 값 허용
+
+		// 새로운 이미지 추가 요청
+		List<MultipartFile> newImages = List.of(
+			new MockMultipartFile("file1", "image1.jpg", "image/jpeg", new byte[] {1, 2, 3})
+		);
+
+		// WHEN & THEN: 이미지 개수 초과 시 예외 발생
+		assertThrows(CustomException.class, () -> goodsService.uploadGoodImages(spyGood.getId(), newImages));
+
+		// 검증: Stub이 올바르게 호출되었는지 확인
+		verify(goodsRepository, times(1)).findById(spyGood.getId());
+		verify(goodsImagesRepository, times(1)).findByGood(spyGood);
+	}
+
+	@Test
+	@DisplayName("물건 이미지 삭제 성공")
+	void deleteGoodImage_Success() {
+		// GIVEN: 존재하는 상품과 이미지
+		Goods spyGood = spy(testGood); // `testGood`을 spy로 감싸서 ID를 설정 가능하게 만듦
+		when(spyGood.getId()).thenReturn(1L); // ID가 1L을 반환하도록 설정
+
+		GoodsImages mockImage = GoodsImages.builder()
+			.good(spyGood)
+			.s3Key("s3-key")
+			.contentType("content-type")
+			.build();
+
+		when(goodsImagesRepository.findById(anyLong())).thenReturn(Optional.of(mockImage));
+
+		// WHEN: 상품 이미지 삭제 수행
+		goodsService.deleteGoodImage(1L, 10L);
+
+		// THEN: S3에서 삭제하고, DB에서 제거되었는지 검증
+		verify(awsS3Service, times(1)).deleteFile(mockImage);
+		verify(goodsImagesRepository, times(1)).delete(mockImage);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 물건 이미지 삭제 실패")
+	void deleteGoodImage_ThrowsException_WhenImageNotFound() {
+		// GIVEN: 존재하지 않는 이미지
+		when(goodsImagesRepository.findById(999L)).thenReturn(Optional.empty());
+
+		// WHEN & THEN: 이미지가 없으면 예외 발생
+		assertThrows(CustomException.class, () -> goodsService.deleteGoodImage(1L, 999L));
+	}
+
+	@Test
+	@DisplayName("다른 상품의 이미지 삭제 실패")
+	void deleteGoodImage_ThrowsException_WhenImageDoesNotBelongToGoods() {
+		// GIVEN: 다른 상품의 이미지
+		Goods testGood2 = Goods.builder()
+			.user(testUser)
+			.title("test 물건")
+			.price(1000L)
+			.quality(GoodsQuality.NEW)
+			.category(testCategory)
+			.content("싸게 드려요! 교환주세요!")
+			.build();
+
+		Goods spyGood2 = spy(testGood2); // testGood2를 spy로 감싸서 ID 설정 가능하게 만듦
+		when(spyGood2.getId()).thenReturn(2L); // ID가 2L을 반환하도록 설정
+
+		GoodsImages mockImage = GoodsImages.builder()
+			.good(spyGood2)
+			.s3Key("s3-key")
+			.contentType("content-type")
+			.build();
+
+		when(goodsImagesRepository.findById(anyLong())).thenReturn(Optional.of(mockImage));
+
+		// WHEN & THEN: 이미지가 다른 상품에 속하면 예외 발생
+		assertThrows(CustomException.class, () -> goodsService.deleteGoodImage(1L, 10L));
+	}
+}

--- a/src/test/java/com/example/swapit/service/UsersServiceTest.java
+++ b/src/test/java/com/example/swapit/service/UsersServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.swapit.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.swapit.domain.Users;
+
+@ExtendWith(MockitoExtension.class)
+class UsersServiceTest {
+
+	@InjectMocks
+	private UsersServiceImpl usersService;
+
+	@Mock
+	private CurrentUserService currentUserService;
+
+	@Mock
+	private AwsS3Service awsS3Service;
+
+	@BeforeEach
+	void setUp() {
+	}
+
+	@Test
+	@DisplayName("유저 프로필 사진 업데이트 성공")
+	void updateProfileImage_Success() {
+		// GIVEN: 현재 로그인된 사용자와 업로드된 이미지 URL 설정
+		Users testUser = Users.builder()
+			.nickname("nickname")
+			.email("test@example.com")
+			.profileImageUrl("http://example.com/image.jpg")
+			.loginInfo("google")
+			.build();
+
+		MultipartFile mockFile = new MockMultipartFile(
+			"file", "profile.jpg", "image/jpeg", new byte[] {1, 2, 3, 4}
+		);
+
+		String newImageUrl = "https://s3.amazonaws.com/bucket/images/users/1";
+
+		// Mock 객체 설정
+		when(currentUserService.getCurrentUser()).thenReturn(testUser);
+		when(awsS3Service.updateUserProfileImage(any(Users.class), any(MultipartFile.class)))
+			.thenReturn(newImageUrl);
+
+		// WHEN: 프로필 이미지를 업데이트
+		usersService.updateProfileImage(mockFile);
+
+		// THEN: 프로필 이미지 URL이 변경되었는지 확인
+		assertEquals(newImageUrl, testUser.getProfileImageUrl());
+
+		// Mock 객체가 올바르게 호출되었는지 검증
+		verify(currentUserService, times(1)).getCurrentUser();
+		verify(awsS3Service, times(1)).updateUserProfileImage(testUser, mockFile);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#33 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- S3 Service를 활용해, UserService에서 사용자 프로필 사진 변경 구현
- AuthService에서 UserInfo 내려줄 때, AwsS3Service의 url pre-signed로 보호된 url 전송하는 로직 적용
- GoodsImages Service 로직 테스트 코드 작성 +  GoodsServiceTest와 분리
- 

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
AuthServiceImpl을 조금 수정했습니다! 확인 부탁드려요!
