### PR TITLE
[feature] 채팅방 http api 구현

### DIFF
--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -48,7 +48,10 @@ public enum ErrorCode {
 	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
 	TRADE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "거래에 대한 권한이 없습니다."),
 	DUPLICATE_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "이미 해당 물건에 스왑 요청한 내역이 있습니다."),
-	MAXIMUM_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "가능한 스왑 요청 횟수를 초과하였습니다.");
+	MAXIMUM_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "가능한 스왑 요청 횟수를 초과하였습니다."),
+
+	// chat error
+	CHATROOMS_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/swapit/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/swapit/config/security/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/user/auth/refresh", "/api/user/auth/logout", "/connection/**")
+				.requestMatchers("/api/user/auth/refresh", "/api/user/auth/logout", "/ws/**")
 				.permitAll()
 				.requestMatchers("/api/all/**")
 				.permitAll() // 누구나 접근 가능

--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/user/auth/logout",
 		"/api/all/sample",
 		"api/all/goods",
-		"/connection"
+		"/ws"
 	);
 
 	@Override

--- a/src/main/java/com/example/swapit/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/swapit/config/websocket/StompHandler.java
@@ -1,12 +1,17 @@
 package com.example.swapit.config.websocket;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
@@ -24,17 +29,28 @@ public class StompHandler implements ChannelInterceptor {
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
-		if (accessor.getCommand() == StompCommand.CONNECT) {
+		if (StompCommand.CONNECT.equals(accessor.getCommand()) ||
+			StompCommand.SEND.equals(accessor.getCommand())) {
 			validateToken(accessor);
 		}
 
-		return message;
+		MessageHeaders headers = accessor.getMessageHeaders();
+		Map<String, Object> newHeaders = new HashMap<>(headers);
+		newHeaders.put("simpUser", accessor.getUser());
+
+		return MessageBuilder.createMessage(message.getPayload(), new MessageHeaders(newHeaders));
 	}
 
 	private void validateToken(StompHeaderAccessor accessor) {
-		boolean validated = jwtProvider.validateToken(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+		String token = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
+		boolean validated = jwtProvider.validateToken(token);
 
-		if (!validated)
+		if (!validated) {
 			throw new CustomException(ErrorCode.VALIDATION_FAIL);
+		}
+
+		String email = jwtProvider.getEmailFromToken(token);
+		StompPrincipal stompPrincipal = new StompPrincipal(email);
+		accessor.setUser(stompPrincipal);
 	}
 }

--- a/src/main/java/com/example/swapit/config/websocket/StompPrincipal.java
+++ b/src/main/java/com/example/swapit/config/websocket/StompPrincipal.java
@@ -1,0 +1,17 @@
+package com.example.swapit.config.websocket;
+
+import java.security.Principal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StompPrincipal implements Principal {
+	private final String email;
+
+	@Override
+	public String getName() {
+		return email;
+	}
+}

--- a/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-	private final StompHandler stompHandler; // jwt 인증
+	private final StompHandler stompHandler;
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -24,10 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/connection")
-			.setAllowedOriginPatterns("*")
-			.withSockJS();
-		registry.addEndpoint("/connection")
+		registry.addEndpoint("/ws")
 			.setAllowedOriginPatterns("*");
 	}
 

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -1,12 +1,30 @@
 package com.example.swapit.controller;
 
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.swapit.domain.dto.ChatMessageDto;
+import com.example.swapit.common.api.ApiResponse;
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.config.websocket.StompPrincipal;
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.ChatStompRequestDto;
+import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.service.ChatService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,11 +32,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatController {
 	private final SimpMessagingTemplate template;
+	private final ChatService chatService;
 
-	@MessageMapping("/chat/{chatroomId}") //여기로 전송되면 메서드 호출 -> WebSocketConfig prefixes 에서 적용한건 앞에 생략
-	@SendTo("/topic/chat/{chatroomId}")   //구독하고 있는 장소로 메시지 전송 (목적지)  -> WebSocketConfig Broker 에서 적용한건 앞에 붙어줘야됨
-	public ChatMessageDto chat(@DestinationVariable Long chatroomId, ChatMessageDto message) {
+	@MessageMapping("/chat/{chatroomId}")
+	@SendTo("/topic/chat/{chatroomId}")
+	public ChatStompResponseDto chat(@DestinationVariable Long chatroomId, ChatStompRequestDto message,
+		Principal principal) {
+		if (principal instanceof StompPrincipal stompPrincipal) {
+			return chatService.saveChat(chatroomId, message, stompPrincipal.getEmail());
+		} else {
+			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
 
-		return message;
+	@PostMapping("/api/user/chatroom")
+	public ApiResponse<Void> addChatRoom(@RequestBody ChatRoomRequestDto chatRoomRequestDto) {
+		chatService.addChatRoom(chatRoomRequestDto);
+		return ApiResponse.success();
+	}
+
+	@GetMapping("/api/user/chatroom")
+	public ApiResponse<List<ChatRoomResponseDto>> getChatRooms() {
+		return ApiResponse.success(chatService.getChatRoomList());
+	}
+
+	@GetMapping("/api/user/chatroom/{chatroomId}")
+	public ApiResponse<ChatListDto> getChats(@PathVariable Long chatroomId,
+		@RequestParam(required = false) Long cursorId,                    // 마지막 조회 항목 ID
+		@RequestParam(required = false) LocalDateTime createdAt        // 최신순일 경우, 커서 기준 값
+	) {
+		return ApiResponse.success(chatService.getChatList(chatroomId, cursorId, createdAt));
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -17,6 +17,7 @@ import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,7 +26,7 @@ public class ChatController {
 	private final ChatService chatService;
 
 	@PostMapping("/api/user/chatroom")
-	public ApiResponse<Long> addChatRoom(@RequestBody ChatRoomRequestDto chatRoomRequestDto) {
+	public ApiResponse<Long> addChatRoom(@Valid @RequestBody ChatRoomRequestDto chatRoomRequestDto) {
 		return ApiResponse.success(chatService.addChatRoom(chatRoomRequestDto));
 	}
 

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -1,13 +1,8 @@
 package com.example.swapit.controller;
 
-import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,14 +11,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
-import com.example.swapit.common.exception.CustomException;
-import com.example.swapit.common.exception.ErrorCode;
-import com.example.swapit.config.websocket.StompPrincipal;
 import com.example.swapit.domain.dto.ChatListDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
-import com.example.swapit.domain.dto.ChatStompRequestDto;
-import com.example.swapit.domain.dto.ChatStompResponseDto;
 import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 
@@ -32,19 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
-	private final SimpMessagingTemplate template;
 	private final ChatService chatService;
-
-	@MessageMapping("/chat/{chatroomId}")
-	@SendTo("/topic/chat/{chatroomId}")
-	public ChatStompResponseDto chat(@DestinationVariable Long chatroomId, ChatStompRequestDto message,
-		Principal principal) {
-		if (principal instanceof StompPrincipal stompPrincipal) {
-			return chatService.saveChat(chatroomId, message, stompPrincipal.getEmail());
-		} else {
-			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
-		}
-	}
 
 	@PostMapping("/api/user/chatroom")
 	public ApiResponse<Long> addChatRoom(@RequestBody ChatRoomRequestDto chatRoomRequestDto) {

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -24,6 +24,7 @@ import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 
 import lombok.RequiredArgsConstructor;
@@ -61,5 +62,10 @@ public class ChatController {
 		@RequestParam(required = false) LocalDateTime createdAt        // 마지막 조회 항목의 생성일
 	) {
 		return ApiResponse.success(chatService.getChatList(chatroomId, cursorId, createdAt));
+	}
+
+	@GetMapping("/api/user/chatroom/{chatroomId}/goods")
+	public ApiResponse<GoodsDto> getChatRoomGoods(@PathVariable Long chatroomId) {
+		return ApiResponse.success(chatService.getChatRoomGoods(chatroomId));
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -46,9 +46,8 @@ public class ChatController {
 	}
 
 	@PostMapping("/api/user/chatroom")
-	public ApiResponse<Void> addChatRoom(@RequestBody ChatRoomRequestDto chatRoomRequestDto) {
-		chatService.addChatRoom(chatRoomRequestDto);
-		return ApiResponse.success();
+	public ApiResponse<Long> addChatRoom(@RequestBody ChatRoomRequestDto chatRoomRequestDto) {
+		return ApiResponse.success(chatService.addChatRoom(chatRoomRequestDto));
 	}
 
 	@GetMapping("/api/user/chatroom")
@@ -59,7 +58,7 @@ public class ChatController {
 	@GetMapping("/api/user/chatroom/{chatroomId}")
 	public ApiResponse<ChatListDto> getChats(@PathVariable Long chatroomId,
 		@RequestParam(required = false) Long cursorId,                    // 마지막 조회 항목 ID
-		@RequestParam(required = false) LocalDateTime createdAt        // 최신순일 경우, 커서 기준 값
+		@RequestParam(required = false) LocalDateTime createdAt        // 마지막 조회 항목의 생성일
 	) {
 		return ApiResponse.success(chatService.getChatList(chatroomId, cursorId, createdAt));
 	}

--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -1,0 +1,36 @@
+package com.example.swapit.controller;
+
+import java.security.Principal;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.config.websocket.StompPrincipal;
+import com.example.swapit.domain.dto.ChatStompRequestDto;
+import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.service.ChatService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+	private final SimpMessagingTemplate template;
+	private final ChatService chatService;
+
+	@MessageMapping("/chat/{chatroomId}")
+	@SendTo("/topic/chat/{chatroomId}")
+	public ChatStompResponseDto chat(@DestinationVariable Long chatroomId, ChatStompRequestDto message,
+		Principal principal) {
+		if (principal instanceof StompPrincipal stompPrincipal) {
+			return chatService.saveChat(chatroomId, message, stompPrincipal.getEmail());
+		} else {
+			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+		}
+	}
+}

--- a/src/main/java/com/example/swapit/domain/ChatRooms.java
+++ b/src/main/java/com/example/swapit/domain/ChatRooms.java
@@ -3,9 +3,11 @@ package com.example.swapit.domain;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,11 +15,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "chatrooms")
 public class ChatRooms {
 
@@ -41,4 +47,11 @@ public class ChatRooms {
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	@Builder
+	public ChatRooms(Goods goods, Users owner, Users requester) {
+		this.goods = goods;
+		this.owner = owner;
+		this.requester = requester;
+	}
 }

--- a/src/main/java/com/example/swapit/domain/ChatRooms.java
+++ b/src/main/java/com/example/swapit/domain/ChatRooms.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "chatrooms")
 public class ChatRooms {

--- a/src/main/java/com/example/swapit/domain/Chats.java
+++ b/src/main/java/com/example/swapit/domain/Chats.java
@@ -3,9 +3,13 @@ package com.example.swapit.domain;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,11 +17,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "chats")
 public class Chats {
 
@@ -34,13 +42,26 @@ public class Chats {
 	@JoinColumn(name = "sender_id", nullable = false)
 	private Users sender;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "chat_type", nullable = false)
 	private ChatType chatType;
 
 	@Column(name = "content", nullable = false)
 	private String content;
 
+	@Column(name = "goods_id")
+	private Long goodsId;
+
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	@Builder
+	public Chats(ChatRooms chatRooms, Users sender, ChatType chatType, String content, Long goodsId) {
+		this.chatRooms = chatRooms;
+		this.sender = sender;
+		this.chatType = chatType;
+		this.content = content;
+		this.goodsId = goodsId;
+	}
 }

--- a/src/main/java/com/example/swapit/domain/dto/ChatDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatDto.java
@@ -1,0 +1,23 @@
+package com.example.swapit.domain.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.swapit.domain.ChatRooms;
+import com.example.swapit.domain.ChatType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatDto {
+	private Long chatsId;
+	private ChatRooms chatRooms;
+	private ChatType chatType;
+	private String content;
+	private RequesterGoodsDto requesterGoods;
+	private Long senderId;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatListDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatListDto.java
@@ -1,0 +1,15 @@
+package com.example.swapit.domain.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatListDto {
+	private List<ChatDto> chatList;
+	private boolean hasNext;
+	private Long lastCursorId;
+	private int size;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
@@ -1,0 +1,9 @@
+package com.example.swapit.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomRequestDto {
+	private Long goodsId;
+	private Long requesterId;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
@@ -1,8 +1,10 @@
 package com.example.swapit.domain.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ChatRoomRequestDto {
 	private Long goodsId;
 	private Long requesterId;

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
@@ -1,11 +1,15 @@
 package com.example.swapit.domain.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class ChatRoomRequestDto {
+	@NotNull(message = "goodsId는 필수 입력 값입니다.")
 	private Long goodsId;
+
+	@NotNull(message = "goodsId는 필수 입력 값입니다.")
 	private Long requesterId;
 }

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomRequestDto.java
@@ -10,6 +10,6 @@ public class ChatRoomRequestDto {
 	@NotNull(message = "goodsId는 필수 입력 값입니다.")
 	private Long goodsId;
 
-	@NotNull(message = "goodsId는 필수 입력 값입니다.")
+	@NotNull(message = "requesterId는 필수 입력 값입니다.")
 	private Long requesterId;
 }

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.swapit.domain.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ChatRoomResponseDto {
+	private Long usersId;
+	private String profileImageUrl;
+	private String nickname;
+	private String recentChat;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatStompRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatStompRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.swapit.domain.dto;
+
+import com.example.swapit.domain.ChatType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatStompRequestDto {
+	private ChatType chatType;
+	private String content;
+	private Long goodsId;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatStompResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatStompResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.swapit.domain.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.swapit.domain.ChatType;
+import com.example.swapit.domain.Chats;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatStompResponseDto {
+	private Long chatsId;
+	private Long senderId;
+	private ChatType chatType;
+	private String content;
+	private LocalDateTime createdAt;
+
+	public ChatStompResponseDto(Chats chats) {
+		this.chatsId = chats.getId();
+		this.senderId = chats.getSender().getUsersId();
+		this.chatType = chats.getChatType();
+		this.content = chats.getContent();
+		this.createdAt = chats.getCreatedAt();
+	}
+}

--- a/src/main/java/com/example/swapit/domain/dto/RequesterGoodsDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/RequesterGoodsDto.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ChatMessageDto {
-	private Long senderId;
-	private String messageType;
-	private String content;
+public class RequesterGoodsDto {
+	private Long goodsId;
+	private String title;
+	private String requesterNickname;
 }

--- a/src/main/java/com/example/swapit/repository/ChatRoomsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatRoomsRepository.java
@@ -1,0 +1,16 @@
+package com.example.swapit.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.swapit.domain.ChatRooms;
+
+public interface ChatRoomsRepository extends JpaRepository<ChatRooms, Long> {
+	List<ChatRooms> findAllByOwnerUsersIdAndRequesterUsersId(Long ownerId, Long requesterId);
+
+	@Query("SELECT c from ChatRooms c WHERE c.owner.id = :usersId OR c.requester.id = :usersId")
+	List<ChatRooms> findByUsersId(@Param("usersId") Long usersId);
+}

--- a/src/main/java/com/example/swapit/repository/ChatsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatsRepository.java
@@ -1,0 +1,24 @@
+package com.example.swapit.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.swapit.domain.Chats;
+
+public interface ChatsRepository extends JpaRepository<Chats, Long> {
+
+	Chats findTopByChatRoomsIdOrderByCreatedAtDesc(Long chatRoomsId);
+
+	@Query("SELECT c FROM Chats c "
+		+ "WHERE c.chatRooms.id = :chatRoomsId "
+		+ "AND (:createdAt IS NULL OR c.createdAt < :createdAt OR (c.createdAt = :createdAt AND c.id < :cursorId)) "
+		+ "ORDER BY c.createdAt DESC")
+	List<Chats> findAllByChatRoomsId(@Param("chatRoomsId") Long chatRoomsId,
+		@Param("cursorId") Long cursorId,
+		@Param("createdAt") LocalDateTime createdAt);
+
+}

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -1,0 +1,20 @@
+package com.example.swapit.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.ChatStompRequestDto;
+import com.example.swapit.domain.dto.ChatStompResponseDto;
+
+public interface ChatService {
+	void addChatRoom(ChatRoomRequestDto chatRoomRequestDto);
+
+	List<ChatRoomResponseDto> getChatRoomList();
+
+	ChatListDto getChatList(Long chatroomId, Long cursorId, LocalDateTime createdAt);
+
+	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, String email);
+}

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -8,6 +8,7 @@ import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.domain.dto.GoodsDto;
 
 public interface ChatService {
 	Long addChatRoom(ChatRoomRequestDto chatRoomRequestDto);
@@ -17,4 +18,6 @@ public interface ChatService {
 	ChatListDto getChatList(Long chatroomId, Long cursorId, LocalDateTime createdAt);
 
 	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, String email);
+
+	GoodsDto getChatRoomGoods(Long chatroomId);
 }

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -10,7 +10,7 @@ import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
 
 public interface ChatService {
-	void addChatRoom(ChatRoomRequestDto chatRoomRequestDto);
+	Long addChatRoom(ChatRoomRequestDto chatRoomRequestDto);
 
 	List<ChatRoomResponseDto> getChatRoomList();
 

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -39,7 +39,7 @@ public class ChatServiceImpl implements ChatService {
 	private static final int size = 30;
 
 	@Override
-	public void addChatRoom(ChatRoomRequestDto chatRoomRequestDto) {
+	public Long addChatRoom(ChatRoomRequestDto chatRoomRequestDto) {
 		Goods goods = goodsRepository.findById(chatRoomRequestDto.getGoodsId())
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 		Users requester = usersRepository.findById(chatRoomRequestDto.getRequesterId())
@@ -49,7 +49,7 @@ public class ChatServiceImpl implements ChatService {
 
 		ChatRooms chatRooms = ChatRooms.builder().goods(goods).owner(owner).requester(requester).build();
 
-		chatRoomsRepository.save(chatRooms);
+		return chatRoomsRepository.save(chatRooms).getId();
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.swapit.domain.ChatRooms;
 import com.example.swapit.domain.ChatType;
 import com.example.swapit.domain.Chats;
 import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ChatDto;
 import com.example.swapit.domain.dto.ChatListDto;
@@ -18,9 +19,11 @@ import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.domain.dto.RequesterGoodsDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
+import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.UsersRepository;
 
@@ -35,6 +38,8 @@ public class ChatServiceImpl implements ChatService {
 	private final CurrentUserService currentUserService;
 	private final ChatRoomsRepository chatRoomsRepository;
 	private final ChatsRepository chatRepository;
+	private final GoodsImagesRepository goodsImagesRepository;
+	private final AwsS3Service awsS3Service;
 
 	private static final int size = 30;
 
@@ -136,5 +141,27 @@ public class ChatServiceImpl implements ChatService {
 
 		chatRepository.save(chats);
 		return new ChatStompResponseDto(chats);
+	}
+
+	@Override
+	public GoodsDto getChatRoomGoods(Long chatroomId) {
+		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
+			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
+		Goods goods = chatRooms.getGoods();
+		String firstImageUrl = goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods)
+			.map(GoodsImages::getS3Key)
+			.map(awsS3Service::generatePreSignedImageUrl)
+			.orElse(null);
+
+		return new GoodsDto(
+			goods.getId(),
+			goods.getTitle(),
+			goods.getPrice(),
+			goods.getCategory().getName(),
+			firstImageUrl,
+			goods.getPlaceName(),
+			goods.getViewCount(),
+			goods.getCreatedAt()
+		);
 	}
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -1,0 +1,140 @@
+package com.example.swapit.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.domain.ChatRooms;
+import com.example.swapit.domain.ChatType;
+import com.example.swapit.domain.Chats;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.ChatDto;
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.ChatStompRequestDto;
+import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.domain.dto.RequesterGoodsDto;
+import com.example.swapit.repository.ChatRoomsRepository;
+import com.example.swapit.repository.ChatsRepository;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.UsersRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+	private final GoodsRepository goodsRepository;
+	private final UsersRepository usersRepository;
+	private final CurrentUserService currentUserService;
+	private final ChatRoomsRepository chatRoomsRepository;
+	private final ChatsRepository chatRepository;
+
+	private static final int size = 30;
+
+	@Override
+	public void addChatRoom(ChatRoomRequestDto chatRoomRequestDto) {
+		Goods goods = goodsRepository.findById(chatRoomRequestDto.getGoodsId())
+			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
+		Users requester = usersRepository.findById(chatRoomRequestDto.getRequesterId())
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		Users owner = usersRepository.findById(goods.getUser().getUsersId())
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		ChatRooms chatRooms = ChatRooms.builder().goods(goods).owner(owner).requester(requester).build();
+
+		chatRoomsRepository.save(chatRooms);
+	}
+
+	@Override
+	public List<ChatRoomResponseDto> getChatRoomList() {
+		Long loggedInUserId = currentUserService.getCurrentUser().getUsersId();
+		List<ChatRooms> chatRooms = chatRoomsRepository.findByUsersId(loggedInUserId);
+
+		return chatRooms.stream().map(chatRoom -> {
+			Long counterpartId =
+				chatRoom.getOwner().getUsersId().equals(loggedInUserId) ? chatRoom.getRequester().getUsersId() :
+					chatRoom.getOwner().getUsersId();
+
+			Users counterpart = usersRepository.findById(counterpartId)
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			String recentChat = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId()).getContent();
+			LocalDateTime createdAt = chatRoom.getCreatedAt();
+
+			return ChatRoomResponseDto.builder()
+				.usersId(counterpartId)
+				.profileImageUrl(counterpart.getProfileImageUrl())
+				.nickname(counterpart.getNickname())
+				.recentChat(recentChat)
+				.createdAt(createdAt)
+				.build();
+		}).toList();
+	}
+
+	@Override
+	public ChatListDto getChatList(Long chatRoomId, Long cursorId, LocalDateTime createdAt) {
+
+		List<Chats> chats = chatRepository.findAllByChatRoomsId(chatRoomId, cursorId, createdAt);
+
+		boolean hasNext = chats.size() > size;
+
+		List<Chats> paginateChats = hasNext ? chats.subList(0, size) : chats;
+
+		Long lastCursorId = paginateChats.isEmpty() ? null : paginateChats.get(paginateChats.size() - 1).getId();
+
+		List<ChatDto> chatList = chats.stream().map(chat -> {
+			if (ChatType.REQUEST.equals(chat.getChatType()) || ChatType.ACCEPT.equals(chat.getChatType())) {
+				Goods goods = goodsRepository.findById(chat.getGoodsId())
+					.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
+
+				RequesterGoodsDto requesterGoods = new RequesterGoodsDto(goods.getId(),
+					goods.getTitle(),
+					goods.getUser().getNickname()
+				);
+				return ChatDto.builder()
+					.chatsId(chat.getId())
+					.chatType(chat.getChatType())
+					.content(chat.getContent())
+					.requesterGoods(requesterGoods)
+					.senderId(chat.getSender().getUsersId())
+					.createdAt(chat.getCreatedAt())
+					.build();
+			} else {
+				return ChatDto.builder()
+					.chatsId(chat.getId())
+					.chatType(chat.getChatType())
+					.content(chat.getContent())
+					.senderId(chat.getSender().getUsersId())
+					.createdAt(chat.getCreatedAt())
+					.build();
+			}
+		}).toList();
+
+		return new ChatListDto(chatList, hasNext, lastCursorId, chatList.size());
+	}
+
+	@Override
+	public ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, String email) {
+		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
+			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
+		Users users = usersRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		Chats chats = Chats.builder()
+			.chatRooms(chatRooms)
+			.sender(users)
+			.chatType(chatDto.getChatType())
+			.content(chatDto.getContent())
+			.goodsId(chatDto.getGoodsId())
+			.build();
+
+		chatRepository.save(chats);
+		return new ChatStompResponseDto(chats);
+	}
+}

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -1,0 +1,159 @@
+package com.example.swapit.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.example.swapit.domain.ChatType;
+import com.example.swapit.domain.dto.ChatDto;
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.GoodsDto;
+import com.example.swapit.service.ChatService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class ChatControllerTest {
+
+	private MockMvc mockMvc;
+
+	@InjectMocks
+	private ChatController chatController;
+
+	@Mock
+	private ChatService chatService;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(chatController).build();
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 성공")
+	void addChatRoomSuccess() throws Exception {
+		// Given
+		ChatRoomRequestDto dto = new ChatRoomRequestDto(1L, 1L);
+
+		doReturn(1L).when(chatService).addChatRoom(org.mockito.ArgumentMatchers.any(ChatRoomRequestDto.class));
+
+		// When & Then
+		mockMvc.perform(post("/api/user/chatroom")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(dto)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."));
+
+		verify(chatService, times(1)).addChatRoom(org.mockito.ArgumentMatchers.any(ChatRoomRequestDto.class));
+	}
+
+	@Test
+	@DisplayName("채팅방 목록 조회 성공")
+	void getChatRoomSuccess() throws Exception {
+		// given
+		ChatRoomResponseDto dto1 = ChatRoomResponseDto.builder()
+			.usersId(1L)
+			.profileImageUrl("http://example.com/image.jpg")
+			.nickname("testUser")
+			.recentChat("안녕하세요!")
+			.build();
+
+		ChatRoomResponseDto dto2 = ChatRoomResponseDto.builder()
+			.usersId(2L)
+			.profileImageUrl("http://example.com/image1.jpg")
+			.nickname("testUser2")
+			.recentChat("안녕하세요!!")
+			.build();
+
+		List<ChatRoomResponseDto> dtoList = List.of(dto1, dto2);
+
+		given(chatService.getChatRoomList()).willReturn(dtoList);
+
+		// when & then
+		mockMvc.perform(get("/api/user/chatroom"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andExpect(jsonPath("$.results", hasSize(2)))
+			.andExpect(jsonPath("$.results[0].usersId").value(1))
+			.andExpect(jsonPath("$.results[0].profileImageUrl").value("http://example.com/image.jpg"))
+			.andExpect(jsonPath("$.results[0].nickname").value("testUser"))
+			.andExpect(jsonPath("$.results[0].recentChat").value("안녕하세요!"))
+			.andExpect(jsonPath("$.results[1].usersId").value(2))
+			.andExpect(jsonPath("$.results[1].profileImageUrl").value("http://example.com/image1.jpg"))
+			.andExpect(jsonPath("$.results[1].nickname").value("testUser2"))
+			.andExpect(jsonPath("$.results[1].recentChat").value("안녕하세요!!"));
+	}
+
+	@Test
+	@DisplayName("채팅 목록 조회 성공")
+	void getChatsSuccess() throws Exception {
+		// given
+		ChatDto dto1 = ChatDto.builder()
+			.chatsId(1L)
+			.chatType(ChatType.TALK)
+			.content("안녕하세요!")
+			.build();
+
+		ChatDto dto2 = ChatDto.builder()
+			.chatsId(2L)
+			.chatType(ChatType.TALK)
+			.content("넵!")
+			.build();
+
+		ChatListDto chatListDto = new ChatListDto(List.of(dto1, dto2), true, 2L, 2);
+
+		given(chatService.getChatList(any(), any(), any())).willReturn(chatListDto);
+
+		// when & then
+		mockMvc.perform(get("/api/user/chatroom/1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andExpect(jsonPath("$.results.chatList").isArray())
+			.andExpect(jsonPath("$.results.chatList[0].content").value("안녕하세요!"))
+			.andExpect(jsonPath("$.results.chatList[1].content").value("넵!"))
+			.andExpect(jsonPath("$.results.hasNext").value(true))
+			.andExpect(jsonPath("$.results.lastCursorId").value(2));
+
+		verify(chatService, times(1)).getChatList(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("채팅방 물건 조회 성공")
+	void getChatRoomGoods() throws Exception {
+		// given
+		GoodsDto dto = new GoodsDto(
+			1L, "아이폰 15", 2500L, "NEW", null, null, 10L, LocalDateTime.now());
+
+		given(chatService.getChatRoomGoods(any())).willReturn(dto);
+
+		// when & then
+		mockMvc.perform(get("/api/user/chatroom/1/goods"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andExpect(jsonPath("$.results.title").value("아이폰 15"));
+
+		verify(chatService, times(1)).getChatRoomGoods(any());
+	}
+}

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -1,0 +1,304 @@
+package com.example.swapit.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.swapit.domain.Categories;
+import com.example.swapit.domain.ChatRooms;
+import com.example.swapit.domain.ChatType;
+import com.example.swapit.domain.Chats;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.GoodsImages;
+import com.example.swapit.domain.GoodsQuality;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.ChatDto;
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.ChatStompRequestDto;
+import com.example.swapit.domain.dto.ChatStompResponseDto;
+import com.example.swapit.domain.dto.GoodsDto;
+import com.example.swapit.repository.ChatRoomsRepository;
+import com.example.swapit.repository.ChatsRepository;
+import com.example.swapit.repository.GoodsImagesRepository;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.UsersRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+	@Mock
+	private ChatRoomsRepository chatRoomsRepository;
+
+	@Mock
+	private ChatsRepository chatRepository;
+
+	@Mock
+	private GoodsRepository goodsRepository;
+
+	@Mock
+	private UsersRepository usersRepository;
+
+	@Mock
+	private GoodsImagesRepository goodsImagesRepository;
+
+	@Mock
+	private CurrentUserService currentUserService;
+
+	@Mock
+	private AwsS3Service awsS3Service;
+
+	@InjectMocks
+	private ChatServiceImpl chatService;
+
+	@Test
+	@DisplayName("채팅방 생성 테스트")
+	void addChatRoom() {
+		// given
+		ChatRoomRequestDto requestDto = new ChatRoomRequestDto(1L, 1L);
+
+		Users requester = Users.builder()
+			.usersId(1L)
+			.email("test@example.com")
+			.build();
+
+		Users owner = Users.builder()
+			.usersId(2L)
+			.email("test@example.com")
+			.build();
+
+		Goods testGood = Goods.builder()
+			.title("test 물건")
+			.price(1000L)
+			.quality(GoodsQuality.NEW)
+			.content("싸게 드려요! 교환주세요!")
+			.user(owner)
+			.build();
+
+		ChatRooms chatRooms = ChatRooms.builder()
+			.goods(testGood)
+			.requester(requester)
+			.owner(owner)
+			.build();
+
+		when(goodsRepository.findById(any())).thenReturn(Optional.of(testGood));
+		when(usersRepository.findById(1L)).thenReturn(Optional.of(requester));
+		when(usersRepository.findById(2L)).thenReturn(Optional.of(owner));
+		when(chatRoomsRepository.save(any())).thenReturn(chatRooms);
+
+		// when
+		chatService.addChatRoom(requestDto);
+
+		// then
+		verify(chatRoomsRepository, times(1)).save(any());
+
+		assertEquals(chatRooms.getGoods(), testGood);
+		assertEquals(chatRooms.getRequester(), requester);
+		assertEquals(chatRooms.getOwner(), owner);
+	}
+
+	@Test
+	@DisplayName("채팅방 목록 조회 성공")
+	void getChatRoomListTest() {
+		// given
+		Users currentUser = Users.builder()
+			.usersId(1L)
+			.email("current@example.com")
+			.build();
+
+		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
+
+		Users owner = Users.builder()
+			.usersId(2L)
+			.email("owner@example.com")
+			.profileImageUrl("http://example.com/profile.jpg")
+			.build();
+
+		ChatRooms chatRoom = ChatRooms.builder()
+			.requester(currentUser)
+			.owner(owner)
+			.build();
+
+		List<ChatRooms> chatRoomsList = List.of(chatRoom);
+		when(chatRoomsRepository.findByUsersId(1L)).thenReturn(chatRoomsList);
+
+		Chats latestChat = Chats.builder()
+			.content("Hello")
+			.build();
+		when(chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(any())).thenReturn(latestChat);
+
+		when(usersRepository.findById(2L)).thenReturn(Optional.of(owner));
+
+		// when
+		List<ChatRoomResponseDto> result = chatService.getChatRoomList();
+
+		// then
+		assertNotNull(result);
+		assertEquals(1, result.size());
+
+		ChatRoomResponseDto dto = result.get(0);
+		assertEquals(2L, dto.getUsersId());
+		assertEquals("http://example.com/profile.jpg", dto.getProfileImageUrl());
+		assertEquals("Hello", dto.getRecentChat());
+	}
+
+	@Test
+	@DisplayName("채팅 목록 조회 성공")
+	void getChatList() {
+		// given
+		Long chatRoomId = 1L;
+		Long cursorId = 0L;
+		LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 12, 0, 0);
+
+		Users sender1 = Users.builder().usersId(100L).build();
+		Users sender2 = Users.builder().usersId(101L).build();
+
+		// 채팅 객체 생성
+		// 채팅1: type = REQUEST, goodsId가 필요함.
+		Chats chat1 = Chats.builder()
+			.chatType(ChatType.REQUEST)
+			.content("Request message")
+			.goodsId(10L)
+			.sender(sender1)
+			.build();
+
+		// 채팅2: type = TALK (goodsRepository 호출 없음)
+		Chats chat2 = Chats.builder()
+			.chatType(ChatType.TALK)
+			.content("Talk message")
+			.sender(sender2)
+			.build();
+
+		List<Chats> chats = List.of(chat1, chat2);
+		when(chatRepository.findAllByChatRoomsId(chatRoomId, cursorId, baseTime))
+			.thenReturn(chats);
+
+		Users goodsOwner = Users.builder()
+			.usersId(200L)
+			.nickname("OwnerNick")
+			.build();
+		Goods goods = Goods.builder()
+			.title("Test Good")
+			.user(goodsOwner)
+			.build();
+		when(goodsRepository.findById(10L))
+			.thenReturn(Optional.of(goods));
+
+		// when
+		ChatListDto result = chatService.getChatList(chatRoomId, cursorId, baseTime);
+
+		// then
+		assertEquals(2, result.getChatList().size());
+
+		// 채팅1 (REQUEST): RequesterGoodsDto가 채팅 DTO에 포함되어야 함.
+		ChatDto dto1 = result.getChatList().get(0);
+		assertEquals(ChatType.REQUEST, dto1.getChatType());
+		assertEquals("Request message", dto1.getContent());
+		assertNotNull(dto1.getRequesterGoods());
+		assertEquals("Test Good", dto1.getRequesterGoods().getTitle());
+
+		// 채팅2 (TALK): RequesterGoodsDto가 null이어야 함.
+		ChatDto dto2 = result.getChatList().get(1);
+		assertEquals(ChatType.TALK, dto2.getChatType());
+		assertEquals("Talk message", dto2.getContent());
+		assertNull(dto2.getRequesterGoods());
+	}
+
+	@Test
+	@DisplayName("채팅 저장 성공")
+	void saveChatSuccessTest() {
+		// given
+		Long chatroomId = 1L;
+		String email = "test@example.com";
+
+		ChatStompRequestDto chatDto = new ChatStompRequestDto(ChatType.TALK, "Hello, this is a test chat", 123L);
+
+		ChatRooms chatRoom = ChatRooms.builder()
+			.id(chatroomId)
+			.build();
+		Users user = Users.builder()
+			.usersId(100L)
+			.email(email)
+			.build();
+
+		when(chatRoomsRepository.findById(chatroomId)).thenReturn(Optional.of(chatRoom));
+		when(usersRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+		Chats savedChat = Chats.builder()
+			.chatRooms(chatRoom)
+			.sender(user)
+			.chatType(chatDto.getChatType())
+			.content(chatDto.getContent())
+			.goodsId(chatDto.getGoodsId())
+			.build();
+
+		when(chatRepository.save(any(Chats.class))).thenReturn(savedChat);
+
+		// when
+		ChatStompResponseDto response = chatService.saveChat(chatroomId, chatDto, email);
+
+		// then
+		assertNotNull(response);
+		assertEquals(chatDto.getContent(), response.getContent());
+		assertEquals(chatDto.getChatType(), response.getChatType());
+
+		verify(chatRepository, times(1)).save(any(Chats.class));
+	}
+
+	@Test
+	@DisplayName("채팅방 상품 조회 성공")
+	void getChatRoomGoods() {
+		// given
+		Long chatroomId = 1L;
+
+		Categories category = Categories.builder()
+			.name("ELECTRONIC").build();
+
+		Goods goods = Goods.builder()
+			.title("Test Good")
+			.price(1000L)
+			.category(category)
+			.placeName("TestPlace")
+			.build();
+
+		ChatRooms chatRooms = ChatRooms.builder()
+			.id(chatroomId)
+			.goods(goods)
+			.build();
+
+		when(chatRoomsRepository.findById(chatroomId))
+			.thenReturn(Optional.of(chatRooms));
+
+		GoodsImages goodsImages = GoodsImages.builder()
+			.s3Key("test-key").build();
+		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods))
+			.thenReturn(Optional.of(goodsImages));
+
+		String expectedImageUrl = "http://example.com/test-image.jpg";
+		when(awsS3Service.generatePreSignedImageUrl("test-key"))
+			.thenReturn(expectedImageUrl);
+
+		// when
+		GoodsDto result = chatService.getChatRoomGoods(chatroomId);
+
+		// then
+		assertNotNull(result);
+		assertEquals(goods.getTitle(), result.getTitle());
+		assertEquals(goods.getPrice(), result.getPrice());
+		assertEquals(category.getName(), result.getCategory());
+		assertEquals(expectedImageUrl, result.getImageUrl());
+		assertEquals(goods.getPlaceName(), result.getPlaceName());
+		assertEquals(goods.getCreatedAt(), result.getCreatedAt());
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #37, #38 

## 📝 작업 내용

> 웹소켓 SEND 메시지 토큰 검증 추가, 채팅 관련 http api 구현, 테스트 코드 작성

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 사용자 검증하는 부분은 추후에 리팩토링 하겠습니다! 채팅방 물건 조회에서 응답을 GoodsDto를 주도록 구현되어 있는데 해당 dto의 모든 정보가 앱에서 필요하진 않습니다... 그냥 dto를 새로 만드는게 나을까요? 뭐가 더 나은지가 항상 고민되는 부분이네요...
