### PR TITLE
[bug] 채팅방 조회 시 채팅 내역 유무 필터링 추가

### DIFF
--- a/src/main/java/com/example/swapit/repository/ChatsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatsRepository.java
@@ -21,4 +21,5 @@ public interface ChatsRepository extends JpaRepository<Chats, Long> {
 		@Param("cursorId") Long cursorId,
 		@Param("createdAt") LocalDateTime createdAt);
 
+	long countByChatRoomsId(Long chatroomId);
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -62,25 +62,28 @@ public class ChatServiceImpl implements ChatService {
 		Long loggedInUserId = currentUserService.getCurrentUser().getUsersId();
 		List<ChatRooms> chatRooms = chatRoomsRepository.findByUsersId(loggedInUserId);
 
-		return chatRooms.stream().map(chatRoom -> {
-			Long counterpartId =
-				chatRoom.getOwner().getUsersId().equals(loggedInUserId) ? chatRoom.getRequester().getUsersId() :
-					chatRoom.getOwner().getUsersId();
+		return chatRooms.stream()
+			.filter(chatRoom -> chatRepository.countByChatRoomsId(chatRoom.getId()) > 0)
+			.map(chatRoom -> {
+				Long counterpartId =
+					chatRoom.getOwner().getUsersId().equals(loggedInUserId) ? chatRoom.getRequester().getUsersId() :
+						chatRoom.getOwner().getUsersId();
 
-			Users counterpart = usersRepository.findById(counterpartId)
-				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+				Users counterpart = usersRepository.findById(counterpartId)
+					.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-			String recentChat = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId()).getContent();
-			LocalDateTime createdAt = chatRoom.getCreatedAt();
+				String recentChat = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId())
+					.getContent();
+				LocalDateTime createdAt = chatRoom.getCreatedAt();
 
-			return ChatRoomResponseDto.builder()
-				.usersId(counterpartId)
-				.profileImageUrl(counterpart.getProfileImageUrl())
-				.nickname(counterpart.getNickname())
-				.recentChat(recentChat)
-				.createdAt(createdAt)
-				.build();
-		}).toList();
+				return ChatRoomResponseDto.builder()
+					.usersId(counterpartId)
+					.profileImageUrl(counterpart.getProfileImageUrl())
+					.nickname(counterpart.getNickname())
+					.recentChat(recentChat)
+					.createdAt(createdAt)
+					.build();
+			}).toList();
 	}
 
 	@Override

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.example.swapit.domain.Categories;
 import com.example.swapit.domain.ChatRooms;
@@ -130,8 +131,12 @@ class ChatServiceTest {
 			.owner(owner)
 			.build();
 
+		ReflectionTestUtils.setField(chatRoom, "id", 1L);
+
 		List<ChatRooms> chatRoomsList = List.of(chatRoom);
 		when(chatRoomsRepository.findByUsersId(1L)).thenReturn(chatRoomsList);
+
+		when(chatRepository.countByChatRoomsId(any())).thenReturn(1L);
 
 		Chats latestChat = Chats.builder()
 			.content("Hello")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> 없습니다

## 📝 작업 내용

> 채팅방 생성 후 채팅방 목록 조회 시 내역이 없을 때 오류가 발생해서 채팅 내역이 있는 채팅방만 조회하도록 필터 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
> 에러 발견해주셔서 감사합니다~~
