### PR TITLE
[build] 로컬과 서버에서의 환경변수 설정 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,10 @@ def loadPropertiesFile(filePath) {
     return props
 }
 
-def sonarToken = project.ext.SONARQUBETOKEN
+// 로컬에서만 사용. 커밋할 때 주석처리하고, 로컬에서 실행할 때는 아래 System.getenv를 주석처리
+//def sonarToken = project.ext.SONARQUBETOKEN
+
+def sonarToken = System.getenv("SONARQUBETOKEN")
 
 sonarqube {
     properties {
@@ -151,14 +154,14 @@ ext {
     snippetsDir = file('build/generated-snippets')
 }
 
-def localServerUrl = project.ext.LOCAL_SERVER_URL
-def serverUrl = project.ext.SERVER_URL
+// 로컬에서만 사용. 커밋할 때 주석처리하고, 로컬에서 실행할 때는 아래 System.getenv를 주석처리
+//def localServerUrl = project.ext.LOCAL_SERVER_URL
+//def serverUrl = project.ext.SERVER_URL
+
+def serverUrl = System.getenv("SERVER_URL")
 
 openapi3 {
-    servers = [
-            { url = localServerUrl },
-            { url = serverUrl }
-    ]
+    server = serverUrl
     title = "Swap It API 문서"
     description = "Spring REST Docs with SwaggerUI."
     version = "0.0.1"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
 
   profiles:
     active:
-      - prd   # 로컬에서는 dev로 변경해서 사용.
+      - dev   # 로컬에서는 dev로 변경해서 사용.
     include:
       - jwt
       - s3

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
 
   profiles:
     active:
-      - dev   # 로컬에서는 dev로 변경해서 사용.
+      - prd   # 로컬에서는 dev로 변경해서 사용.
     include:
       - jwt
       - s3


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없음

## 📝 작업 내용

> 로컬에서는 .env 파일을 사용하고 서버에서는 환경변수를 사용하기 때문에 분리하여 주석 처리

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 깃허브에 올릴때는 System.getenv를 사용하고 로컬에서 실행할때는 project.ext.를 사용하면 됩니다!
