### PR TITLE
[feat] 유저 페이지 조회 구현

### DIFF
--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/all/auth/login/google",
 		"/api/all/auth/login/kakao",
 		"/api/user/auth/logout",
+		"/api/all/auth/info",
 		"/api/all/sample",
 		"api/all/goods",
 		"/ws"

--- a/src/main/java/com/example/swapit/controller/UserController.java
+++ b/src/main/java/com/example/swapit/controller/UserController.java
@@ -5,7 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,6 +15,7 @@ import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.config.security.CustomUserDetails;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.UserNicknameDto;
+import com.example.swapit.domain.dto.UserPageDto;
 import com.example.swapit.domain.dto.UserResponseDTO;
 import com.example.swapit.service.UsersService;
 
@@ -21,12 +24,14 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class UserController {
 
 	private final UsersService usersService;
 
+	// todo : 현재 쓰고 있는 곳이 아예 없는지 확인 후, 삭제 필수.
 	// 사용자 정보 가져오는 임시 코드
-	@GetMapping("api/user/me")
+	@GetMapping("/user/me")
 	public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 		if (customUserDetails == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 정보가 없습니다.");
@@ -41,13 +46,23 @@ public class UserController {
 		return ResponseEntity.ok(userResponseDTO);
 	}
 
-	@PatchMapping("/api/user/auth/profile/image")
+	@GetMapping("/user/auth/info/my")
+	public ApiResponse<UserPageDto> getMyPage() {
+		return ApiResponse.success(usersService.getMyPage());
+	}
+
+	@GetMapping("/all/auth/info/{userId}")
+	public ApiResponse<UserPageDto> getAnotherUserPage(@PathVariable Long userId) {
+		return ApiResponse.success(usersService.getAnotherUserPage(userId));
+	}
+
+	@PatchMapping("/user/auth/profile/image")
 	public ApiResponse<Void> updateProfileImage(MultipartFile image) {
 		usersService.updateProfileImage(image);
 		return ApiResponse.success();
 	}
 
-	@PatchMapping("/api/user/auth/profile/nickname")
+	@PatchMapping("/user/auth/profile/nickname")
 	public ApiResponse<Void> updateProfileNickname(@Valid @RequestBody UserNicknameDto dto) {
 		usersService.updateNickname(dto);
 		return ApiResponse.success();

--- a/src/main/java/com/example/swapit/controller/UserController.java
+++ b/src/main/java/com/example/swapit/controller/UserController.java
@@ -1,8 +1,5 @@
 package com.example.swapit.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,11 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.swapit.common.api.ApiResponse;
-import com.example.swapit.config.security.CustomUserDetails;
-import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.UserNicknameDto;
 import com.example.swapit.domain.dto.UserPageDto;
-import com.example.swapit.domain.dto.UserResponseDTO;
 import com.example.swapit.service.UsersService;
 
 import jakarta.validation.Valid;
@@ -28,23 +22,6 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UsersService usersService;
-
-	// todo : 현재 쓰고 있는 곳이 아예 없는지 확인 후, 삭제 필수.
-	// 사용자 정보 가져오는 임시 코드
-	@GetMapping("/user/me")
-	public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-		if (customUserDetails == null) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 정보가 없습니다.");
-		}
-		Users user = customUserDetails.getUser();
-		UserResponseDTO userResponseDTO = UserResponseDTO.builder()
-			.nickname(user.getNickname())
-			.email(user.getEmail())
-			.profileImgUrl(user.getProfileImageUrl())
-			.loginInfo(user.getLoginInfo())
-			.build();
-		return ResponseEntity.ok(userResponseDTO);
-	}
 
 	@GetMapping("/user/auth/info/my")
 	public ApiResponse<UserPageDto> getMyPage() {

--- a/src/main/java/com/example/swapit/domain/dto/UserPageDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserPageDto.java
@@ -1,0 +1,25 @@
+package com.example.swapit.domain.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserPageDto {
+	private Long usersId;
+	private String nickname;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String email;
+	private String profileImageUrl;
+	private long totalGoodsCount;
+	private long completedSwapCount;
+	private double ratingAverage;
+	private List<ReviewDto> reviews;
+}

--- a/src/main/java/com/example/swapit/repository/GoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/GoodsRepository.java
@@ -10,4 +10,6 @@ import com.example.swapit.domain.Users;
 public interface GoodsRepository extends JpaRepository<Goods, Long>, CustomGoodsRepository {
 
 	List<Goods> findByUserOrderByCreatedAtDesc(Users user);
+
+	long countByUser(Users user);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -13,8 +13,8 @@ import io.lettuce.core.dynamic.annotation.Param;
 public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 	List<Reviews> findAllByRevieweeOrderByCreatedAtDesc(Users reviewee);
 
-	@Query("SELECT AVG(r.rating) FROM Reviews r WHERE r.reviewee = :reviewee")
-	double averageRatingByReviewee(@Param("reviewee") Users reviewee);
+	@Query("SELECT COALESCE(AVG(r.rating), 0.0) FROM Reviews r WHERE r.reviewee = :reviewee")
+	Double averageRatingByReviewee(@Param("reviewee") Users reviewee);
 
 	List<Reviews> findTop3ByRevieweeOrderByCreatedAtDesc(Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -3,10 +3,18 @@ package com.example.swapit.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.swapit.domain.Reviews;
 import com.example.swapit.domain.Users;
 
+import io.lettuce.core.dynamic.annotation.Param;
+
 public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 	List<Reviews> findAllByRevieweeOrderByCreatedAtDesc(Users reviewee);
+
+	@Query("SELECT AVG(r.rating) FROM Reviews r WHERE r.reviewee = :reviewee")
+	double averageRatingByReviewee(@Param("reviewee") Users reviewee);
+
+	List<Reviews> findTop3ByRevieweeOrderByCreatedAtDesc(Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -6,11 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.Trades;
+import com.example.swapit.domain.Users;
 
 import io.lettuce.core.dynamic.annotation.Param;
 
 public interface TradesRepository extends JpaRepository<Trades, Long> {
 	long countByTargetGoodsIdAndIsDeletedFalse(Long goodsId);
+
+	@Query("SELECT COUNT(*) FROM Trades t WHERE ( t.owner = :user OR t.requester = :user ) AND t.status = 'COMPLETED'")
+	long countByCompletedTradesByUser(@Param("user") Users user);
 
 	@Modifying
 	@Query("UPDATE Trades t SET t.status = 'REJECTED' WHERE t.targetGoods = :targetGoods AND t.id <> :acceptedTradeId")

--- a/src/main/java/com/example/swapit/service/UsersService.java
+++ b/src/main/java/com/example/swapit/service/UsersService.java
@@ -6,7 +6,9 @@ import com.example.swapit.domain.dto.UserNicknameDto;
 import com.example.swapit.domain.dto.UserPageDto;
 
 public interface UsersService {
-	UserPageDto getUserMyPage(Long userId);
+	UserPageDto getMyPage();
+
+	UserPageDto getAnotherUserPage(Long userId);
 
 	void updateProfileImage(MultipartFile file);
 

--- a/src/main/java/com/example/swapit/service/UsersService.java
+++ b/src/main/java/com/example/swapit/service/UsersService.java
@@ -3,8 +3,11 @@ package com.example.swapit.service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.swapit.domain.dto.UserNicknameDto;
+import com.example.swapit.domain.dto.UserPageDto;
 
 public interface UsersService {
+	UserPageDto getUserMyPage(Long userId);
+
 	void updateProfileImage(MultipartFile file);
 
 	void updateNickname(UserNicknameDto dto);

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -1,13 +1,22 @@
 package com.example.swapit.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.ReviewDto;
 import com.example.swapit.domain.dto.UserNicknameDto;
+import com.example.swapit.domain.dto.UserPageDto;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.ReviewRepository;
+import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -18,6 +27,33 @@ public class UsersServiceImpl implements UsersService {
 	private final CurrentUserService currentUserService;
 	private final AwsS3Service awsS3Service;
 	private final UsersRepository usersRepository;
+	private final GoodsRepository goodsRepository;
+	private final TradesRepository tradesRepository;
+	private final ReviewRepository reviewRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public UserPageDto getUserMyPage(Long userId) {
+		Users user = usersRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		Users me = currentUserService.getCurrentUser();
+		boolean isMyPage = (user.getUsersId().equals(me.getUsersId()));
+
+		long totalUsersGoodsCount = goodsRepository.countByUser(user);
+		long completedSwapCount = tradesRepository.countByCompletedTradesByUser(user);
+		double averageRating = reviewRepository.averageRatingByReviewee(user);
+		List<ReviewDto> reviews = reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)
+			.stream()
+			.map(ReviewDto::of)
+			.toList();
+
+		return new UserPageDto(
+			user.getUsersId(), user.getNickname(),
+			(isMyPage ? user.getEmail() : null),
+			user.getProfileImageUrl(), totalUsersGoodsCount, completedSwapCount, averageRating, reviews
+		);
+	}
 
 	@Override
 	public void updateProfileImage(MultipartFile file) {

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -33,12 +33,8 @@ public class UsersServiceImpl implements UsersService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public UserPageDto getUserMyPage(Long userId) {
-		Users user = usersRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-		Users me = currentUserService.getCurrentUser();
-		boolean isMyPage = (user.getUsersId().equals(me.getUsersId()));
+	public UserPageDto getMyPage() {
+		Users user = currentUserService.getCurrentUser();
 
 		long totalUsersGoodsCount = goodsRepository.countByUser(user);
 		long completedSwapCount = tradesRepository.countByCompletedTradesByUser(user);
@@ -49,9 +45,27 @@ public class UsersServiceImpl implements UsersService {
 			.toList();
 
 		return new UserPageDto(
-			user.getUsersId(), user.getNickname(),
-			(isMyPage ? user.getEmail() : null),
-			user.getProfileImageUrl(), totalUsersGoodsCount, completedSwapCount, averageRating, reviews
+			user.getUsersId(), user.getNickname(), user.getEmail(), user.getProfileImageUrl(),
+			totalUsersGoodsCount, completedSwapCount, averageRating, reviews
+		);
+	}
+
+	@Override
+	public UserPageDto getAnotherUserPage(Long userId) {
+		Users user = usersRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		long totalUsersGoodsCount = goodsRepository.countByUser(user);
+		long completedSwapCount = tradesRepository.countByCompletedTradesByUser(user);
+		double averageRating = reviewRepository.averageRatingByReviewee(user);
+		List<ReviewDto> reviews = reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)
+			.stream()
+			.map(ReviewDto::of)
+			.toList();
+
+		return new UserPageDto(
+			user.getUsersId(), user.getNickname(), null, user.getProfileImageUrl(),
+			totalUsersGoodsCount, completedSwapCount, averageRating, reviews
 		);
 	}
 

--- a/src/test/java/com/example/swapit/controller/UserControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/UserControllerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.swapit.domain.dto.UserNicknameDto;
+import com.example.swapit.domain.dto.UserPageDto;
 import com.example.swapit.service.UsersService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -35,9 +38,55 @@ class UserControllerTest {
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
+	UserPageDto userPageDto;
+
 	@BeforeEach
 	void setUp() {
 		mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+		userPageDto = new UserPageDto(
+			1L, "testUser", "test@example.com",
+			"https://profile.img", 10L, 5L, 4.5,
+			List.of()  // 리뷰 리스트는 비워둠
+		);
+	}
+
+	@Test
+	@DisplayName("로그인된 사용자 마이페이지 조회 성공")
+	void getMyPage_Success() throws Exception {
+		// Given
+		when(usersService.getMyPage()).thenReturn(userPageDto);
+
+		// When & Then
+		mockMvc.perform(get("/api/user/auth/info/my")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.usersId").value(1L))
+			.andExpect(jsonPath("$.results.nickname").value("testUser"))
+			.andExpect(jsonPath("$.results.email").value("test@example.com"))
+			.andExpect(jsonPath("$.results.profileImageUrl").value("https://profile.img"))
+			.andExpect(jsonPath("$.results.totalGoodsCount").value(10L))
+			.andExpect(jsonPath("$.results.completedSwapCount").value(5L))
+			.andExpect(jsonPath("$.results.ratingAverage").value(4.5));
+	}
+
+	@Test
+	@DisplayName("다른 사용자 페이지 조회 성공")
+	void getAnotherUserPage_Success() throws Exception {
+		// Given
+		when(usersService.getAnotherUserPage(2L)).thenReturn(userPageDto);
+
+		// When & Then
+		mockMvc.perform(get("/api/all/auth/info/{userId}", 2L)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.usersId").value(1L))
+			.andExpect(jsonPath("$.results.nickname").value("testUser"))
+			.andExpect(jsonPath("$.results.profileImageUrl").value("https://profile.img"))
+			.andExpect(jsonPath("$.results.totalGoodsCount").value(10L))
+			.andExpect(jsonPath("$.results.completedSwapCount").value(5L))
+			.andExpect(jsonPath("$.results.ratingAverage").value(4.5));
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/service/UsersServiceTest.java
+++ b/src/test/java/com/example/swapit/service/UsersServiceTest.java
@@ -3,6 +3,9 @@ package com.example.swapit.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.UserPageDto;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.ReviewRepository;
+import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.UsersRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UsersServiceTest {
@@ -27,21 +36,94 @@ class UsersServiceTest {
 	@Mock
 	private AwsS3Service awsS3Service;
 
+	@Mock
+	private GoodsRepository goodsRepository;
+
+	@Mock
+	private TradesRepository tradesRepository;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private UsersRepository usersRepository;
+
+	private Users user;
+
 	@BeforeEach
 	void setUp() {
-	}
-
-	@Test
-	@DisplayName("유저 프로필 사진 업데이트 성공")
-	void updateProfileImage_Success() {
-		// GIVEN: 현재 로그인된 사용자와 업로드된 이미지 URL 설정
-		Users testUser = Users.builder()
+		user = Users.builder()
+			.usersId(1L)
 			.nickname("nickname")
 			.email("test@example.com")
 			.profileImageUrl("http://example.com/image.jpg")
 			.loginInfo("google")
 			.build();
+	}
 
+	@Test
+	@DisplayName("마이페이지 조회 성공")
+	void getUserMyPageSameCurrentUser_Success() {
+		// given
+		when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
+		when(currentUserService.getCurrentUser()).thenReturn(user);
+		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
+		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
+		when(reviewRepository.averageRatingByReviewee(user)).thenReturn(4.5); // 평균 평점 4.5
+		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
+
+		// when
+		UserPageDto result = usersService.getUserMyPage(1L);
+
+		// then
+		assertNotNull(result);
+		assertEquals(1L, result.getUsersId());
+		assertEquals("nickname", result.getNickname());
+		assertEquals("test@example.com", result.getEmail());
+		assertEquals(5L, result.getTotalGoodsCount());
+		assertEquals(3L, result.getCompletedSwapCount());
+		assertEquals(4.5, result.getRatingAverage());
+	}
+
+	@Test
+	@DisplayName("다른 회원 유저페이지 조회 성공")
+	void getUserMyPageDifferentCurrentUser_Success() {
+		// given
+		Users currentUser = Users.builder().usersId(2L).build();
+		when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
+		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
+		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
+		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
+		when(reviewRepository.averageRatingByReviewee(user)).thenReturn(4.5); // 평균 평점 4.5
+		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
+
+		// when
+		UserPageDto result = usersService.getUserMyPage(1L);
+
+		// then
+		assertNotNull(result);
+		assertEquals(1L, result.getUsersId());
+		assertEquals("nickname", result.getNickname());
+		assertNull(result.getEmail());
+		assertEquals(5L, result.getTotalGoodsCount());
+		assertEquals(3L, result.getCompletedSwapCount());
+		assertEquals(4.5, result.getRatingAverage());
+	}
+
+	@Test
+	@DisplayName("유저 페이지 가져오기 실패 - 유저를 찾을 수 없음")
+	void getUserMyPage_Fail_byUserNotFound() {
+		// Given
+		when(usersRepository.findById(99L)).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThrows(CustomException.class, () -> usersService.getUserMyPage(99L));
+	}
+
+	@Test
+	@DisplayName("유저 프로필 사진 업데이트 성공")
+	void updateProfileImage_Success() {
+		// given
 		MultipartFile mockFile = new MockMultipartFile(
 			"file", "profile.jpg", "image/jpeg", new byte[] {1, 2, 3, 4}
 		);
@@ -49,7 +131,7 @@ class UsersServiceTest {
 		String newImageUrl = "https://s3.amazonaws.com/bucket/images/users/1";
 
 		// Mock 객체 설정
-		when(currentUserService.getCurrentUser()).thenReturn(testUser);
+		when(currentUserService.getCurrentUser()).thenReturn(user);
 		when(awsS3Service.updateUserProfileImage(any(Users.class), any(MultipartFile.class)))
 			.thenReturn(newImageUrl);
 
@@ -57,10 +139,10 @@ class UsersServiceTest {
 		usersService.updateProfileImage(mockFile);
 
 		// THEN: 프로필 이미지 URL이 변경되었는지 확인
-		assertEquals(newImageUrl, testUser.getProfileImageUrl());
+		assertEquals(newImageUrl, user.getProfileImageUrl());
 
 		// Mock 객체가 올바르게 호출되었는지 검증
 		verify(currentUserService, times(1)).getCurrentUser();
-		verify(awsS3Service, times(1)).updateUserProfileImage(testUser, mockFile);
+		verify(awsS3Service, times(1)).updateUserProfileImage(user, mockFile);
 	}
 }

--- a/src/test/java/com/example/swapit/service/UsersServiceTest.java
+++ b/src/test/java/com/example/swapit/service/UsersServiceTest.java
@@ -63,9 +63,8 @@ class UsersServiceTest {
 
 	@Test
 	@DisplayName("마이페이지 조회 성공")
-	void getUserMyPageSameCurrentUser_Success() {
+	void getMyPage_Success() {
 		// given
-		when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
 		when(currentUserService.getCurrentUser()).thenReturn(user);
 		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
 		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
@@ -73,7 +72,7 @@ class UsersServiceTest {
 		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
 
 		// when
-		UserPageDto result = usersService.getUserMyPage(1L);
+		UserPageDto result = usersService.getMyPage();
 
 		// then
 		assertNotNull(result);
@@ -87,18 +86,17 @@ class UsersServiceTest {
 
 	@Test
 	@DisplayName("다른 회원 유저페이지 조회 성공")
-	void getUserMyPageDifferentCurrentUser_Success() {
+	void getAnotherUserPage_Success() {
 		// given
 		Users currentUser = Users.builder().usersId(2L).build();
 		when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
-		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
 		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
 		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
 		when(reviewRepository.averageRatingByReviewee(user)).thenReturn(4.5); // 평균 평점 4.5
 		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
 
 		// when
-		UserPageDto result = usersService.getUserMyPage(1L);
+		UserPageDto result = usersService.getAnotherUserPage(1L);
 
 		// then
 		assertNotNull(result);
@@ -117,7 +115,7 @@ class UsersServiceTest {
 		when(usersRepository.findById(99L)).thenReturn(Optional.empty());
 
 		// When & Then
-		assertThrows(CustomException.class, () -> usersService.getUserMyPage(99L));
+		assertThrows(CustomException.class, () -> usersService.getAnotherUserPage(99L));
 	}
 
 	@Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closed #59 

## 📝 작업 내용

유저 마이페이지 조회 api 구현

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
- 다시 마이페이지 조회 api 2개로 쪼갬
  - 어제 얘기했을 때 하나의 api 로 합치는 걸로 구현하자고 결론이 났었지만, 구현하면서 로그인 한 사람, 로그인 안 한 사람을 동시에 받는 api가 되어야 하는데  `로그인을 안 한 사용자`를 받으려면 jwtfilter를 넘겨야 하고, `로그인 한 사람`은 jwtFilter에서 UserDetails에 정보를 주입해서 principal에 담기게 되는데 그 2개를 동시에 받을 수 있도록 구현하는 것보다 api를 나누는게 더 나을 것 같아 **다시 2개의 api로 쪼개는 것**으로 변경하였습니다!
- 그리고  // 사용자 정보 가져오는 임시 코드 @GetMapping("api/user/me") 이 부분은 더이상 사용하지 않는 것 같아 삭제 처리했습니다!
