### PR TITLE
Feature/write docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     // test container
     testImplementation 'org.testcontainers:junit-jupiter:1.18.0'
-    testImplementation 'org.testcontainers:mysql:1.18.0'
+    testImplementation 'org.testcontainers:mysql:1.17.1'
 }
 
 // .env 파일 읽기
@@ -174,8 +174,20 @@ openapi3 {
     outputDirectory = 'build/resources/main/static/docs'
 }
 
+task cleanDocsFolder(type: Delete) {
+    delete "${openapi3.outputDirectory}"
+}
+
+task cleanSnippetsFolder(type: Delete) {
+    delete "build/generated-snippets"
+}
+
 tasks.whenTaskAdded { task ->
+    if (task.name == 'test') {
+        task.dependsOn(cleanSnippetsFolder)
+    }
     if (task.name == 'openapi3') {
+        task.dependsOn(cleanDocsFolder)
         task.dependsOn(test)
     }
     if (task.name == 'addSecurityToOpenApi') {

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     // test container
     testImplementation 'org.testcontainers:junit-jupiter:1.18.0'
-    testImplementation 'org.testcontainers:mysql:1.17.1'
+    testImplementation 'org.testcontainers:mysql:1.18.0'
 }
 
 // .env 파일 읽기

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
 import com.example.swapit.domain.dto.ChatRoomListResponseDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
-import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 
 import jakarta.validation.Valid;
@@ -43,7 +43,7 @@ public class ChatController {
 	}
 
 	@GetMapping("/api/user/chatroom/{chatroomId}/goods")
-	public ApiResponse<GoodsDto> getChatRoomGoods(@PathVariable Long chatroomId) {
+	public ApiResponse<ChatRoomGoodsDto> getChatRoomGoods(@PathVariable Long chatroomId) {
 		return ApiResponse.success(chatService.getChatRoomGoods(chatroomId));
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -1,7 +1,6 @@
 package com.example.swapit.controller;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomListResponseDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
-import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 
@@ -31,8 +30,8 @@ public class ChatController {
 	}
 
 	@GetMapping("/api/user/chatroom")
-	public ApiResponse<List<ChatRoomResponseDto>> getChatRooms() {
-		return ApiResponse.success(chatService.getChatRoomList());
+	public ApiResponse<ChatRoomListResponseDto> getChatRooms() {
+		return ApiResponse.success(new ChatRoomListResponseDto(chatService.getChatRoomList()));
 	}
 
 	@GetMapping("/api/user/chatroom/{chatroomId}")

--- a/src/main/java/com/example/swapit/domain/dto/ChatDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatDto.java
@@ -2,7 +2,6 @@ package com.example.swapit.domain.dto;
 
 import java.time.LocalDateTime;
 
-import com.example.swapit.domain.ChatRooms;
 import com.example.swapit.domain.ChatType;
 
 import lombok.AllArgsConstructor;
@@ -14,7 +13,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ChatDto {
 	private Long chatsId;
-	private ChatRooms chatRooms;
 	private ChatType chatType;
 	private String content;
 	private RequesterGoodsDto requesterGoods;

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomGoodsDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomGoodsDto.java
@@ -1,0 +1,14 @@
+package com.example.swapit.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomGoodsDto {
+	private Long goodsId;
+	private String title;
+	private String category;
+	private long price;
+	private String imageUrl;
+}

--- a/src/main/java/com/example/swapit/domain/dto/ChatRoomListResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ChatRoomListResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.swapit.domain.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomListResponseDto {
+	private List<ChatRoomResponseDto> chatRoomList;
+}

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -4,11 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
-import com.example.swapit.domain.dto.GoodsDto;
 
 public interface ChatService {
 	Long addChatRoom(ChatRoomRequestDto chatRoomRequestDto);
@@ -19,5 +19,5 @@ public interface ChatService {
 
 	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, Long userId);
 
-	GoodsDto getChatRoomGoods(Long chatroomId);
+	ChatRoomGoodsDto getChatRoomGoods(Long chatroomId);
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -16,11 +16,11 @@ import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ChatDto;
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
-import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.domain.dto.RequesterGoodsDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
@@ -156,7 +156,7 @@ public class ChatServiceImpl implements ChatService {
 	}
 
 	@Override
-	public GoodsDto getChatRoomGoods(Long chatroomId) {
+	public ChatRoomGoodsDto getChatRoomGoods(Long chatroomId) {
 		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
 			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
 		Goods goods = chatRooms.getGoods();
@@ -165,15 +165,12 @@ public class ChatServiceImpl implements ChatService {
 			.map(awsS3Service::generatePreSignedImageUrl)
 			.orElse(null);
 
-		return new GoodsDto(
+		return new ChatRoomGoodsDto(
 			goods.getId(),
 			goods.getTitle(),
-			goods.getPrice(),
 			goods.getCategory().getName(),
-			firstImageUrl,
-			goods.getPlaceName(),
-			goods.getViewCount(),
-			goods.getCreatedAt()
+			goods.getPrice(),
+			firstImageUrl
 		);
 	}
 }

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,9 +22,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.example.swapit.domain.ChatType;
 import com.example.swapit.domain.dto.ChatDto;
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
-import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.service.ChatService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -142,8 +141,8 @@ class ChatControllerTest {
 	@DisplayName("채팅방 물건 조회 성공")
 	void getChatRoomGoods() throws Exception {
 		// given
-		GoodsDto dto = new GoodsDto(
-			1L, "아이폰 15", 2500L, "NEW", null, null, 10L, LocalDateTime.now());
+		ChatRoomGoodsDto dto = new ChatRoomGoodsDto(
+			1L, "아이폰 15", "ELECTRONICS", 2500L, null);
 
 		given(chatService.getChatRoomGoods(any())).willReturn(dto);
 

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -93,15 +93,15 @@ class ChatControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
-			.andExpect(jsonPath("$.results", hasSize(2)))
-			.andExpect(jsonPath("$.results[0].usersId").value(1))
-			.andExpect(jsonPath("$.results[0].profileImageUrl").value("http://example.com/image.jpg"))
-			.andExpect(jsonPath("$.results[0].nickname").value("testUser"))
-			.andExpect(jsonPath("$.results[0].recentChat").value("안녕하세요!"))
-			.andExpect(jsonPath("$.results[1].usersId").value(2))
-			.andExpect(jsonPath("$.results[1].profileImageUrl").value("http://example.com/image1.jpg"))
-			.andExpect(jsonPath("$.results[1].nickname").value("testUser2"))
-			.andExpect(jsonPath("$.results[1].recentChat").value("안녕하세요!!"));
+			.andExpect(jsonPath("$.results.chatRoomList", hasSize(2)))
+			.andExpect(jsonPath("$.results.chatRoomList[0].usersId").value(1))
+			.andExpect(jsonPath("$.results.chatRoomList[0].profileImageUrl").value("http://example.com/image.jpg"))
+			.andExpect(jsonPath("$.results.chatRoomList[0].nickname").value("testUser"))
+			.andExpect(jsonPath("$.results.chatRoomList[0].recentChat").value("안녕하세요!"))
+			.andExpect(jsonPath("$.results.chatRoomList[1].usersId").value(2))
+			.andExpect(jsonPath("$.results.chatRoomList[1].profileImageUrl").value("http://example.com/image1.jpg"))
+			.andExpect(jsonPath("$.results.chatRoomList[1].nickname").value("testUser2"))
+			.andExpect(jsonPath("$.results.chatRoomList[1].recentChat").value("안녕하세요!!"));
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/docs/AuthControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/AuthControllerDocsTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.example.swapit.controller.AuthController;
 import com.example.swapit.domain.dto.TokenDTO;
 import com.example.swapit.service.AuthServiceImpl;
@@ -58,6 +59,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.refreshToken").type(JsonFieldType.STRING).description("발급된 리프레시 토큰"),
 						fieldWithPath("results.key").type(JsonFieldType.STRING).description("사용자 이메일")
 					)
+					.responseSchema(Schema.schema("ApiResponse<TokenDto>"))
 					.build()
 				)
 			));
@@ -93,6 +95,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.refreshToken").type(JsonFieldType.STRING).description("발급된 리프레시 토큰"),
 						fieldWithPath("results.key").type(JsonFieldType.STRING).description("사용자 이메일")
 					)
+					.responseSchema(Schema.schema("ApiResponse<TokenDto>"))
 					.build()
 				)
 			));
@@ -128,6 +131,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.refreshToken").type(JsonFieldType.STRING).description("발급된 리프레시 토큰"),
 						fieldWithPath("results.key").type(JsonFieldType.STRING).description("사용자 이메일")
 					)
+					.responseSchema(Schema.schema("ApiResponse<TokenDto>"))
 					.build()
 				)
 			));
@@ -151,6 +155,7 @@ public class AuthControllerDocsTest extends RestDocsTest {
 				resource(ResourceSnippetParameters.builder()
 					.tag("Auth")
 					.description("리프레시 토큰을 헤더로 받아 로그아웃하는 API")
+					.responseSchema(Schema.schema("ApiResponse"))
 					.build()
 				)
 			));

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -1,0 +1,231 @@
+package com.example.swapit.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.example.swapit.controller.ChatController;
+import com.example.swapit.domain.ChatType;
+import com.example.swapit.domain.dto.ChatDto;
+import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.ChatRoomRequestDto;
+import com.example.swapit.domain.dto.ChatRoomResponseDto;
+import com.example.swapit.service.ChatServiceImpl;
+
+public class ChatControllerDocsTest extends RestDocsTest {
+	private final ChatServiceImpl chatService = mock(ChatServiceImpl.class);
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	protected Object initController() {
+		return new ChatController(chatService);
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 성공")
+	void getChatRoomsSuccess() throws Exception {
+		// Given
+		ChatRoomRequestDto dto = new ChatRoomRequestDto(1L, 1L);
+		doReturn(1L).when(chatService).addChatRoom(any(ChatRoomRequestDto.class));
+
+		// When & Then
+		mockMvc.perform(post("/api/user/chatroom")
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(dto)))
+			.andExpect(status().isOk())
+			.andDo(document("add-chatroom",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Chat")
+					.description("채팅방을 생성하는 API")
+					.requestFields(
+						fieldWithPath("goodsId").type(JsonFieldType.NUMBER).description("물건 ID"),
+						fieldWithPath("requesterId").type(JsonFieldType.NUMBER).description("채팅 시작 사용자 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.NUMBER).description("응답 결과 데이터")
+					)
+					.requestSchema(Schema.schema(" ChatRoomRequestDto"))
+					.responseSchema(Schema.schema("ApiResponse<Long>"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("채팅방 목록 조회 성공")
+	void addChatRoomSuccess() throws Exception {
+		// Given
+		List<ChatRoomResponseDto> dtoList = new ArrayList<>();
+		ChatRoomResponseDto dto = ChatRoomResponseDto.builder()
+			.usersId(1L)
+			.profileImageUrl("http://example.com/image.jpg")
+			.nickname("testUser")
+			.recentChat("안녕하세요!")
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		dtoList.add(dto);
+		given(chatService.getChatRoomList()).willReturn(dtoList);
+
+		// When & Then
+		mockMvc.perform(get("/api/user/chatroom")
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("get-chatroom-list",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(new CustomDatePreprocessor()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Chat")
+					.description("채팅방 목록을 조회하는 API")
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.chatRoomList").type(JsonFieldType.ARRAY).description("채팅방 목록"),
+						fieldWithPath("results.chatRoomList[].usersId").type(JsonFieldType.NUMBER)
+							.description("사용자 ID"),
+						fieldWithPath("results.chatRoomList[].profileImageUrl").type(JsonFieldType.STRING)
+							.description("프로필 이미지 URL"),
+						fieldWithPath("results.chatRoomList[].nickname").type(JsonFieldType.STRING).description("닉네임"),
+						fieldWithPath("results.chatRoomList[].recentChat").type(JsonFieldType.STRING)
+							.description("최근 메세지"),
+						fieldWithPath("results.chatRoomList[].createdAt").type(JsonFieldType.STRING).description("생성시각")
+					)
+					.responseSchema(Schema.schema("ChatRoomListResponseDto"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("채팅 내역 조회 성공")
+	void getChatList() throws Exception {
+		// Given
+		Long chatroomId = 1L;
+		ChatDto dto1 = ChatDto.builder()
+			.chatsId(1L)
+			.chatType(ChatType.TALK)
+			.content("안녕하세요!")
+			.senderId(1L)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		ChatDto dto2 = ChatDto.builder()
+			.chatsId(2L)
+			.chatType(ChatType.TALK)
+			.content("넵!")
+			.senderId(2L)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		ChatListDto chatListDto = new ChatListDto(List.of(dto1, dto2), true, 2L, 2);
+
+		given(chatService.getChatList(anyLong(), any(), any())).willReturn(chatListDto);
+
+		mockMvc.perform(get("/api/user/chatroom/{chatroomId}", chatroomId)
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("get-chat-list",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(new CustomDatePreprocessor()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Chat")
+					.description("채팅 내역을 조회하는 API")
+					.pathParameters(
+						parameterWithName("chatroomId").description("조회할 채팅방 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.chatList").type(JsonFieldType.ARRAY).description("채팅 목록"),
+						fieldWithPath("results.chatList[].chatsId").type(JsonFieldType.NUMBER).description("채팅 ID"),
+						fieldWithPath("results.chatList[].chatType").type(JsonFieldType.STRING).description("채팅 유형"),
+						fieldWithPath("results.chatList[].content").type(JsonFieldType.STRING).description("채팅 내용"),
+						fieldWithPath("results.chatList[].senderId").type(JsonFieldType.NUMBER).description("발신자 ID"),
+						fieldWithPath("results.chatList[].createdAt").type(JsonFieldType.STRING)
+							.description("채팅 생성 시각"),
+						fieldWithPath("results.chatList[].requesterGoods").optional()
+							.type(JsonFieldType.OBJECT)
+							.description("스왑 요청 물건 정보 (대화 유형에 따라 존재)"),
+						fieldWithPath("results.chatList[].requesterGoods.id").optional()
+							.type(JsonFieldType.NUMBER)
+							.description("스왑 요청 물건 ID"),
+						fieldWithPath("results.chatList[].requesterGoods.title").optional()
+							.type(JsonFieldType.STRING)
+							.description("스왑 요청 물건 제목"),
+						fieldWithPath("results.chatList[].requesterGoods.nickname").optional()
+							.type(JsonFieldType.STRING)
+							.description("스왑 요청 물건 작성자 닉네임"),
+						fieldWithPath("results.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+						fieldWithPath("results.lastCursorId").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
+						fieldWithPath("results.size").type(JsonFieldType.NUMBER).description("대화 목록 전체 개수")
+					)
+					.responseSchema(Schema.schema("ChatRoomListResponseDto"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("채팅방 물건 조회 성공")
+	void getChatRoomGoods() throws Exception {
+		// Given
+		Long chatroomId = 1L;
+		ChatRoomGoodsDto dto = new ChatRoomGoodsDto(
+			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg");
+
+		given(chatService.getChatRoomGoods(any())).willReturn(dto);
+
+		// When & Then
+		mockMvc.perform(get("/api/user/chatroom/{chatroomId}/goods", chatroomId))
+			.andExpect(status().isOk())
+			.andDo(document("get-chat-room-goods",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Chat")
+					.description("채팅 방의 물건을 조회하는 API")
+					.pathParameters(
+						parameterWithName("chatroomId").description("조회할 채팅방 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.goodsId").type(JsonFieldType.NUMBER).description("물건 ID"),
+						fieldWithPath("results.title").type(JsonFieldType.STRING).description("물건 제목"),
+						fieldWithPath("results.category").type(JsonFieldType.STRING).description("물건 카테고리"),
+						fieldWithPath("results.price").type(JsonFieldType.NUMBER).description("물건 예상 가격"),
+						fieldWithPath("results.imageUrl").type(JsonFieldType.STRING).description("물건 이미지 URL")
+					)
+					.responseSchema(Schema.schema("ChatRoomGoodsDto"))
+					.build()
+				)
+			));
+	}
+}

--- a/src/test/java/com/example/swapit/docs/CustomDatePreprocessor.java
+++ b/src/test/java/com/example/swapit/docs/CustomDatePreprocessor.java
@@ -1,0 +1,89 @@
+package com.example.swapit.docs;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.restdocs.operation.OperationRequest;
+import org.springframework.restdocs.operation.OperationResponse;
+import org.springframework.restdocs.operation.OperationResponseFactory;
+import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class CustomDatePreprocessor implements OperationPreprocessor {
+
+	@Override
+	public OperationRequest preprocess(OperationRequest operationRequest) {
+		return null;
+	}
+
+	@Override
+	public OperationResponse preprocess(OperationResponse response) {
+		// Jackson ObjectMapper를 생성하고 JavaTimeModule 등록, 날짜를 문자열로 직렬화하도록 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		// 응답 본문을 JSON 트리로 파싱
+		String content = response.getContentAsString();
+		JsonNode rootNode;
+		try {
+			rootNode = objectMapper.readTree(content);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+
+		// results 노드가 존재하면 처리
+		JsonNode resultsNode = rootNode.get("results");
+		if (resultsNode != null) {
+			// 처리할 배열 필드 이름들을 리스트로 정의
+			List<String> listFieldNames = Arrays.asList("goodsList", "chatRoomList", "chatList");
+			for (String fieldName : listFieldNames) {
+				JsonNode arrayNode = resultsNode.get(fieldName);
+				if (arrayNode != null && arrayNode.isArray()) {
+					for (JsonNode itemNode : arrayNode) {
+						JsonNode createdAtNode = itemNode.get("createdAt");
+						if (createdAtNode != null && createdAtNode.isArray() && createdAtNode.size() == 7) {
+							int year = createdAtNode.get(0).asInt();
+							int month = createdAtNode.get(1).asInt();
+							int day = createdAtNode.get(2).asInt();
+							int hour = createdAtNode.get(3).asInt();
+							int minute = createdAtNode.get(4).asInt();
+							int second = createdAtNode.get(5).asInt();
+							int nano = createdAtNode.get(6).asInt();
+
+							// ISO-8601 형식의 문자열로 변환
+							String isoDate = String.format("%04d-%02d-%02dT%02d:%02d:%02d.%09d",
+								year, month, day, hour, minute, second, nano);
+
+							// 기존 createdAt 배열 대신 ISO 문자열로 교체
+							((ObjectNode)itemNode).put("createdAt", isoDate);
+						}
+					}
+				}
+			}
+		}
+
+		// 수정된 JSON 트리를 문자열로 다시 직렬화하여 새 바이트 배열을 준비
+		String newContent;
+		try {
+			newContent = objectMapper.writeValueAsString(rootNode);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		byte[] newContentBytes = newContent.getBytes();
+
+		// 새로운 OperationResponse를 만들어 반환
+		OperationResponseFactory responseFactory = new OperationResponseFactory();
+		return responseFactory.create(
+			response.getStatus(),         // 기존 상태 코드
+			response.getHeaders(),        // 기존 헤더
+			newContentBytes
+		);
+	}
+}

--- a/src/test/java/com/example/swapit/docs/CustomDatePreprocessor.java
+++ b/src/test/java/com/example/swapit/docs/CustomDatePreprocessor.java
@@ -41,29 +41,17 @@ public class CustomDatePreprocessor implements OperationPreprocessor {
 		// results 노드가 존재하면 처리
 		JsonNode resultsNode = rootNode.get("results");
 		if (resultsNode != null) {
-			// 처리할 배열 필드 이름들을 리스트로 정의
-			List<String> listFieldNames = Arrays.asList("goodsList", "chatRoomList", "chatList");
-			for (String fieldName : listFieldNames) {
-				JsonNode arrayNode = resultsNode.get(fieldName);
-				if (arrayNode != null && arrayNode.isArray()) {
-					for (JsonNode itemNode : arrayNode) {
-						JsonNode createdAtNode = itemNode.get("createdAt");
-						if (createdAtNode != null && createdAtNode.isArray() && createdAtNode.size() == 7) {
-							int year = createdAtNode.get(0).asInt();
-							int month = createdAtNode.get(1).asInt();
-							int day = createdAtNode.get(2).asInt();
-							int hour = createdAtNode.get(3).asInt();
-							int minute = createdAtNode.get(4).asInt();
-							int second = createdAtNode.get(5).asInt();
-							int nano = createdAtNode.get(6).asInt();
-
-							// ISO-8601 형식의 문자열로 변환
-							String isoDate = String.format("%04d-%02d-%02dT%02d:%02d:%02d.%09d",
-								year, month, day, hour, minute, second, nano);
-
-							// 기존 createdAt 배열 대신 ISO 문자열로 교체
-							((ObjectNode)itemNode).put("createdAt", isoDate);
+			// 처리할 필드 이름들을 리스트로 정의
+			List<String> fieldNames = Arrays.asList("goodsList", "chatRoomList", "chatList");
+			for (String fieldName : fieldNames) {
+				JsonNode node = resultsNode.get(fieldName);
+				if (node != null) {
+					if (node.isArray()) {
+						for (JsonNode itemNode : node) {
+							processCreatedAtField(itemNode);
 						}
+					} else if (node.isObject()) {
+						processCreatedAtField(node);
 					}
 				}
 			}
@@ -85,5 +73,24 @@ public class CustomDatePreprocessor implements OperationPreprocessor {
 			response.getHeaders(),        // 기존 헤더
 			newContentBytes
 		);
+	}
+
+	// createdAt 필드를 처리하는 메서드
+	private void processCreatedAtField(JsonNode itemNode) {
+		JsonNode createdAtNode = itemNode.get("createdAt");
+		if (createdAtNode != null && createdAtNode.isArray() && createdAtNode.size() == 7) {
+			int year = createdAtNode.get(0).asInt();
+			int month = createdAtNode.get(1).asInt();
+			int day = createdAtNode.get(2).asInt();
+			int hour = createdAtNode.get(3).asInt();
+			int minute = createdAtNode.get(4).asInt();
+			int second = createdAtNode.get(5).asInt();
+			int nano = createdAtNode.get(6).asInt();
+
+			// ISO-8601 형식의 문자열로 변환
+			String isoDate = String.format("%04d-%02d-%02dT%02d:%02d:%02d.%09d",
+				year, month, day, hour, minute, second, nano);
+			((ObjectNode)itemNode).put("createdAt", isoDate);
+		}
 	}
 }

--- a/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
@@ -46,13 +46,12 @@ public class TradesControllerDocsTest extends RestDocsTest {
 		doNothing().when(tradesService).requestTrade(any(TradesRequestDto.class));
 
 		ObjectMapper objectMapper = new ObjectMapper();
-		String requestBody = objectMapper.writeValueAsString(dto);
 
 		// When & Then
 		mockMvc.perform(post("/api/user/swap/request")
 				.header("Authorization", token)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(requestBody))
+				.content(objectMapper.writeValueAsString(dto)))
 			.andExpect(status().isOk())
 			.andDo(document("swap-request",
 				preprocessRequest(prettyPrint()),
@@ -109,6 +108,102 @@ public class TradesControllerDocsTest extends RestDocsTest {
 	}
 
 	@Test
+	@DisplayName("거래 수락 성공")
+	void acceptTradeSuccess() throws Exception {
+		// Given
+		Long tradeId = 1L;
+		doNothing().when(tradesService).acceptTrade(tradeId);
+
+		// When & Then
+		mockMvc.perform(patch("/api/user/swap/accept/{tradesId}", tradeId)
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("accept-swap",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑 요청을 수락하는 API")
+					.pathParameters(
+						parameterWithName("tradesId").description("수락할 스왑 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터").optional()
+					)
+					.responseSchema(Schema.schema("ApiResponse"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("거래 거절 성공")
+	void rejectTradeSuccess() throws Exception {
+		// Given
+		Long tradeId = 1L;
+		doNothing().when(tradesService).acceptTrade(tradeId);
+
+		// When & Then
+		mockMvc.perform(patch("/api/user/swap/reject/{tradesId}", tradeId)
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("reject-swap",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑 요청을 거절하는 API")
+					.pathParameters(
+						parameterWithName("tradesId").description("거절할 스왑 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터").optional()
+					)
+					.responseSchema(Schema.schema("ApiResponse"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("거래 완료 성공")
+	void completeTradeSuccess() throws Exception {
+		// Given
+		Long tradeId = 1L;
+		doNothing().when(tradesService).acceptTrade(tradeId);
+
+		// When & Then
+		mockMvc.perform(patch("/api/user/swap/complete/{tradesId}", tradeId)
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("complete-swap",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑을 완료하는 API")
+					.pathParameters(
+						parameterWithName("tradesId").description("완료할 스왑 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터").optional()
+					)
+					.responseSchema(Schema.schema("ApiResponse"))
+					.build()
+				)
+			));
+	}
+
+	@Test
 	@DisplayName("스왑 목록의 내 물건 목록 조회 성공")
 	void getSwapMyGoods() throws Exception {
 		// given
@@ -136,7 +231,7 @@ public class TradesControllerDocsTest extends RestDocsTest {
 			.andExpect(jsonPath("$.results.goodsList").isArray())
 			.andDo(document("get-swap-my-goods",
 				preprocessRequest(prettyPrint()),
-				preprocessResponse(prettyPrint()),
+				preprocessResponse(new CustomDatePreprocessor()),
 				resource(ResourceSnippetParameters.builder()
 					.tag("Swap")
 					.description("스왑 목록에서 내 물건 목록을 조회하는 API")
@@ -155,7 +250,7 @@ public class TradesControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.goodsList[].viewCount").type(JsonFieldType.NUMBER).description("조회수"),
 						fieldWithPath("results.goodsList[].requestCount").type(JsonFieldType.NUMBER)
 							.description("스왑 요청 수"),
-						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.ARRAY).description("등록 시간")
+						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.STRING).description("등록 시간")
 					)
 					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<MyGoodsDto>>"))
 					.build()
@@ -190,7 +285,7 @@ public class TradesControllerDocsTest extends RestDocsTest {
 			.andExpect(jsonPath("$.results.goodsList").isArray())
 			.andDo(document("get-swap-my-goods-request",
 				preprocessRequest(prettyPrint()),
-				preprocessResponse(prettyPrint()),
+				preprocessResponse(new CustomDatePreprocessor()),
 				resource(ResourceSnippetParameters.builder()
 					.tag("Swap")
 					.description("내 물건에 스왑 요청 받은 물건 목록을 조회하는 API")
@@ -206,7 +301,7 @@ public class TradesControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.goodsList[].placeName").type(JsonFieldType.STRING).description("물건 위치"),
 						fieldWithPath("results.goodsList[].photoUrl").type(JsonFieldType.STRING)
 							.description("물건 이미지 URL"),
-						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.ARRAY).description("등록 시간")
+						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.STRING).description("등록 시간")
 					)
 					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<ReceivedRequestDto>>"))
 					.build()

--- a/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
@@ -1,0 +1,165 @@
+package com.example.swapit.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.example.swapit.controller.TradesController;
+import com.example.swapit.domain.dto.TradesRequestDto;
+import com.example.swapit.domain.dto.trade.MyGoodsDto;
+import com.example.swapit.service.TradesServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TradesControllerDocsTest extends RestDocsTest {
+
+	private final TradesServiceImpl tradesService = mock(TradesServiceImpl.class);
+
+	@Override
+	protected Object initController() {
+		return new TradesController(tradesService);
+	}
+
+	@Test
+	@DisplayName("스왑 요청 성공")
+	void requestSwapSuccess() throws Exception {
+		// Given
+		String token = "Bearer valid_token";
+		TradesRequestDto dto = new TradesRequestDto(1L, 2L);
+
+		doNothing().when(tradesService).requestTrade(any(TradesRequestDto.class));
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String requestBody = objectMapper.writeValueAsString(dto);
+
+		// When & Then
+		mockMvc.perform(post("/api/user/swap/request")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andDo(document("swap-request",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑을 요청하는 API")
+					.requestFields(
+						fieldWithPath("requestedGoodsId").type(JsonFieldType.NUMBER).description("스왑 요청한 물건 ID"),
+						fieldWithPath("targetGoodsId").type(JsonFieldType.NUMBER).description("스왑 요청 대상 물건 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터").optional()
+					)
+					.requestSchema(Schema.schema("TradesRequestDto"))
+					.responseSchema(Schema.schema("ApiResponse"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("스왑 요청 취소 성공")
+	void cancelSwapSuccess() throws Exception {
+		// Given
+		String token = "Bearer valid_token";
+		Long tradesId = 1L;
+
+		doNothing().when(tradesService).cancelTrade(tradesId);
+
+		// When & Then
+		mockMvc.perform(delete("/api/user/swap/cancel/{tradesId}", tradesId)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(document("swap-cancel",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑 요청을 취소하는 API")
+					.pathParameters(
+						parameterWithName("tradesId").description("취소할 스왑 ID")
+					)
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터").optional()
+					)
+					.responseSchema(Schema.schema("ApiResponse"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("스왑 목록의 내 물건 목록 조회 성공")
+	void testGetMyGoods() throws Exception {
+		// given
+		List<MyGoodsDto> goodsList = new ArrayList<>();
+		MyGoodsDto dummyGoods = new MyGoodsDto(
+			1L,
+			"스타벅스 텀블러",
+			35000L,
+			"MISC",
+			"경기도 안산시",
+			"http://example.com/image.jpg",
+			100L,
+			5L,
+			LocalDateTime.now()
+		);
+		goodsList.add(dummyGoods);
+		when(tradesService.getMyGoods()).thenReturn(goodsList);
+
+		// when & then
+		mockMvc.perform(get("/api/user/swap/my-goods")
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.goodsList").isArray())
+			.andDo(document("swap-my-goods",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("내 물건 목록을 조회하는 API")
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.goodsList").type(JsonFieldType.ARRAY).description("내 물건 목록"),
+						fieldWithPath("results.goodsList[].goodsId").type(JsonFieldType.NUMBER).description("물건 ID"),
+						fieldWithPath("results.goodsList[].title").type(JsonFieldType.STRING).description("물건 제목"),
+						fieldWithPath("results.goodsList[].price").type(JsonFieldType.NUMBER).description("물건 가격"),
+						fieldWithPath("results.goodsList[].category").type(JsonFieldType.STRING).description("물건 카테고리"),
+						fieldWithPath("results.goodsList[].placeName").type(JsonFieldType.STRING).description("물건 위치"),
+						fieldWithPath("results.goodsList[].photoUrl").type(JsonFieldType.STRING)
+							.description("물건 이미지 URL"),
+						fieldWithPath("results.goodsList[].viewCount").type(JsonFieldType.NUMBER).description("조회수"),
+						fieldWithPath("results.goodsList[].requestCount").type(JsonFieldType.NUMBER)
+							.description("스왑 요청 수"),
+						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.ARRAY).description("등록 시간")
+					)
+					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<MyGoodsDto>>"))
+					.build()
+				)
+			));
+	}
+}

--- a/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/TradesControllerDocsTest.java
@@ -22,6 +22,8 @@ import com.epages.restdocs.apispec.Schema;
 import com.example.swapit.controller.TradesController;
 import com.example.swapit.domain.dto.TradesRequestDto;
 import com.example.swapit.domain.dto.trade.MyGoodsDto;
+import com.example.swapit.domain.dto.trade.MyRequestDto;
+import com.example.swapit.domain.dto.trade.ReceivedRequestDto;
 import com.example.swapit.service.TradesServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -78,14 +80,12 @@ public class TradesControllerDocsTest extends RestDocsTest {
 	@DisplayName("스왑 요청 취소 성공")
 	void cancelSwapSuccess() throws Exception {
 		// Given
-		String token = "Bearer valid_token";
 		Long tradesId = 1L;
-
 		doNothing().when(tradesService).cancelTrade(tradesId);
 
 		// When & Then
 		mockMvc.perform(delete("/api/user/swap/cancel/{tradesId}", tradesId)
-				.header("Authorization", token)
+				.header("Authorization", "Bearer valid_token")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(document("swap-cancel",
@@ -110,7 +110,7 @@ public class TradesControllerDocsTest extends RestDocsTest {
 
 	@Test
 	@DisplayName("스왑 목록의 내 물건 목록 조회 성공")
-	void testGetMyGoods() throws Exception {
+	void getSwapMyGoods() throws Exception {
 		// given
 		List<MyGoodsDto> goodsList = new ArrayList<>();
 		MyGoodsDto dummyGoods = new MyGoodsDto(
@@ -134,12 +134,12 @@ public class TradesControllerDocsTest extends RestDocsTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.results.goodsList").isArray())
-			.andDo(document("swap-my-goods",
+			.andDo(document("get-swap-my-goods",
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				resource(ResourceSnippetParameters.builder()
 					.tag("Swap")
-					.description("내 물건 목록을 조회하는 API")
+					.description("스왑 목록에서 내 물건 목록을 조회하는 API")
 					.responseFields(
 						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
 						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -158,6 +158,108 @@ public class TradesControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.ARRAY).description("등록 시간")
 					)
 					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<MyGoodsDto>>"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("내 물건에 스왑 요청 받은 물건 목록 조회 성공")
+	void getMyGoodsRequest() throws Exception {
+		// given
+		Long goodsId = 1L;
+		List<ReceivedRequestDto> requestList = new ArrayList<>();
+		ReceivedRequestDto dummyGoods = new ReceivedRequestDto(
+			1L,
+			"스타벅스 텀블러",
+			35000L,
+			"MISC",
+			"경기도 안산시",
+			"http://example.com/image.jpg",
+			LocalDateTime.now()
+		);
+		requestList.add(dummyGoods);
+		when(tradesService.getGoodsRequests(goodsId)).thenReturn(requestList);
+
+		// when & then
+		mockMvc.perform(get("/api/user/swap/my-goods/{goodsId}/requests", goodsId)
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.goodsList").isArray())
+			.andDo(document("get-swap-my-goods-request",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("내 물건에 스왑 요청 받은 물건 목록을 조회하는 API")
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.goodsList").type(JsonFieldType.ARRAY).description("내 물건 목록"),
+						fieldWithPath("results.goodsList[].goodsId").type(JsonFieldType.NUMBER).description("물건 ID"),
+						fieldWithPath("results.goodsList[].title").type(JsonFieldType.STRING).description("물건 제목"),
+						fieldWithPath("results.goodsList[].price").type(JsonFieldType.NUMBER).description("물건 가격"),
+						fieldWithPath("results.goodsList[].category").type(JsonFieldType.STRING).description("물건 카테고리"),
+						fieldWithPath("results.goodsList[].placeName").type(JsonFieldType.STRING).description("물건 위치"),
+						fieldWithPath("results.goodsList[].photoUrl").type(JsonFieldType.STRING)
+							.description("물건 이미지 URL"),
+						fieldWithPath("results.goodsList[].createdAt").type(JsonFieldType.ARRAY).description("등록 시간")
+					)
+					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<ReceivedRequestDto>>"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("내가 보낸 스왑 요청 목록 조회 성공")
+	void getMyRequest() throws Exception {
+		// given
+		List<MyRequestDto> requestList = new ArrayList<>();
+		MyRequestDto dummyGoods = new MyRequestDto(
+			1L,
+			"스타벅스 텀블러",
+			35000L,
+			"MISC",
+			"경기도 안산시",
+			"http://example.com/my-goods.jpg",
+			"http://example.com/requested-goods.jpg"
+		);
+		requestList.add(dummyGoods);
+		when(tradesService.getMyRequests()).thenReturn(requestList);
+
+		// when & then
+		mockMvc.perform(get("/api/user/swap/my-requests")
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.goodsList").isArray())
+			.andDo(document("get-my-request",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Swap")
+					.description("스왑 요청 보낸 물건 목록을 조회하는 API")
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.goodsList").type(JsonFieldType.ARRAY).description("내 물건 목록"),
+						fieldWithPath("results.goodsList[].goodsId").type(JsonFieldType.NUMBER).description("물건 ID"),
+						fieldWithPath("results.goodsList[].title").type(JsonFieldType.STRING).description("물건 제목"),
+						fieldWithPath("results.goodsList[].price").type(JsonFieldType.NUMBER).description("물건 가격"),
+						fieldWithPath("results.goodsList[].category").type(JsonFieldType.STRING).description("물건 카테고리"),
+						fieldWithPath("results.goodsList[].placeName").type(JsonFieldType.STRING).description("물건 위치"),
+						fieldWithPath("results.goodsList[].myGoodsPhotoUrl").type(JsonFieldType.STRING)
+							.description("내 물건 이미지 URL"),
+						fieldWithPath("results.goodsList[].requestedGoodsPhotoUrl").type(JsonFieldType.STRING)
+							.description("요청한 물건 이미지 URL")
+					)
+					.responseSchema(Schema.schema("ApiResponse<TradesGoodsListResponseDto<MyRequestDto>>"))
 					.build()
 				)
 			));

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -25,11 +25,11 @@ import com.example.swapit.domain.GoodsQuality;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ChatDto;
 import com.example.swapit.domain.dto.ChatListDto;
+import com.example.swapit.domain.dto.ChatRoomGoodsDto;
 import com.example.swapit.domain.dto.ChatRoomRequestDto;
 import com.example.swapit.domain.dto.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.ChatStompRequestDto;
 import com.example.swapit.domain.dto.ChatStompResponseDto;
-import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
@@ -300,7 +300,7 @@ class ChatServiceTest {
 			.thenReturn(expectedImageUrl);
 
 		// when
-		GoodsDto result = chatService.getChatRoomGoods(chatroomId);
+		ChatRoomGoodsDto result = chatService.getChatRoomGoods(chatroomId);
 
 		// then
 		assertNotNull(result);
@@ -308,7 +308,5 @@ class ChatServiceTest {
 		assertEquals(goods.getPrice(), result.getPrice());
 		assertEquals(category.getName(), result.getCategory());
 		assertEquals(expectedImageUrl, result.getImageUrl());
-		assertEquals(goods.getPlaceName(), result.getPlaceName());
-		assertEquals(goods.getCreatedAt(), result.getCreatedAt());
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #63 

## 📝 작업 내용

> 채팅방 응답 dto 추가
> test, openapi3 실행 전 폴더 삭제 태스크 추가
> 거래, 채팅 문서화 테스트 코드 작성

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> jackson이 LocaldateTime 형식을 직렬화할 때 배열로 직렬화하게 되어있어서 createdAt을 ISO-8601 형식의 문자열로 변환하도록 CustomDatePreprocessor를 추가했습니다. 엔티티에 format을 지정하는 방법으로 해결해보려 했지만 적용이 안돼서 일단 잘 적용이 되는 방법으로 처리해놨습니다. 추후에 가능하면 더 간단한 방법으로 리팩토링 해보겠습니다! 

> createdAt을 응답으로 보내는 테스트 코드에는 preprocessResponse(new CustomDatePreprocessor())라고 작성 후에 CustomDatePreprocessor 파일의 listFieldNames에 응답 객체 이름을 추가하면 됩니다.
