### PR TITLE
[hotfix] 간단한 유저 프로필 정보를 내려줄 때, 유저 프로필 이미지 추가 및 평균 평점 추가

### DIFF
--- a/src/main/java/com/example/swapit/domain/dto/GoodsDetailDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/GoodsDetailDto.java
@@ -28,10 +28,10 @@ public class GoodsDetailDto {
 	private List<GoodsImageDto> images;
 	private LocalDateTime createdAt;
 
-	public static GoodsDetailDto of(Goods good, List<GoodsImageDto> images) {
+	public static GoodsDetailDto of(Goods good, UserProfileDto userProfileDto, List<GoodsImageDto> images) {
 		return GoodsDetailDto.builder()
 			.goodsId(good.getId())
-			.user(UserProfileDto.of(good.getUser()))
+			.user(userProfileDto)
 			.category(good.getCategory().getName())
 			.title(good.getTitle())
 			.price(good.getPrice())

--- a/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
@@ -16,13 +16,12 @@ public class UserProfileDto {
 	private String profileImageUrl;
 	private Double userRating;
 
-	public static UserProfileDto of(Users user) {
-		// todo : 평균 평점 필드 생성 후, 변경 필요.
+	public static UserProfileDto of(Users user, Double averageRating) {
 		return UserProfileDto.builder()
 			.userId(user.getUsersId())
 			.nickname(user.getNickname())
 			.profileImageUrl(user.getProfileImageUrl())
-			.userRating(0.0)
+			.userRating(averageRating)
 			.build();
 	}
 }

--- a/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 public class UserProfileDto {
 	private Long userId;
 	private String nickname;
+	private String profileImageUrl;
 	private Double userRating;
 
 	public static UserProfileDto of(Users user) {
@@ -20,6 +21,7 @@ public class UserProfileDto {
 		return UserProfileDto.builder()
 			.userId(user.getUsersId())
 			.nickname(user.getNickname())
+			.profileImageUrl(user.getProfileImageUrl())
 			.userRating(0.0)
 			.build();
 	}

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -18,9 +18,11 @@ import com.example.swapit.domain.dto.GoodsDto;
 import com.example.swapit.domain.dto.GoodsImageDto;
 import com.example.swapit.domain.dto.GoodsListDto;
 import com.example.swapit.domain.dto.GoodsRequestDto;
+import com.example.swapit.domain.dto.UserProfileDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.ReviewRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ public class GoodsServiceImpl implements GoodsService {
 	private final CategoriesRepository categoriesRepository;
 	private final CurrentUserService currentUserService;
 	private final GoodsImagesRepository goodsImagesRepository;
+	private final ReviewRepository reviewRepository;
 	private final AwsS3Service awsS3Service;
 
 	private static final int size = 30;
@@ -92,6 +95,10 @@ public class GoodsServiceImpl implements GoodsService {
 		Goods good = goodsRepository.findById(goodsId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 
+		// 유저 프로필 생성
+		Double averageRating = reviewRepository.averageRatingByReviewee(good.getUser());
+		UserProfileDto userProfileDto = UserProfileDto.of(good.getUser(), averageRating);
+
 		// todo :  redis로 ip 제한 걸어서 30초 이내로 다시 요청할 때 변경 가능하도록 하능하게 하면 비기능 향상.
 		// 물건의 viewCount 증가 (새로고침할 때 viewCount가 무한히 증가됨. -> 이 부분은.)
 		good.incrementViewCount();
@@ -102,7 +109,7 @@ public class GoodsServiceImpl implements GoodsService {
 			.map(image -> new GoodsImageDto(image.getId(), awsS3Service.generatePreSignedImageUrl(image.getS3Key())))
 			.toList();
 
-		return GoodsDetailDto.of(good, photos);
+		return GoodsDetailDto.of(good, userProfileDto, photos);
 	}
 
 	@Override

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -88,7 +88,7 @@ class GoodsControllerTest {
 		// given
 		GoodsDetailDto mockGoodsDetail = new GoodsDetailDto(
 			1L,
-			new UserProfileDto(1L, "testUser", 4.8),
+			new UserProfileDto(1L, "testUser", "profileImage", 4.8),
 			"전자기기",
 			"아이폰 15",
 			1200L,

--- a/src/test/java/com/example/swapit/service/GoodServiceTest.java
+++ b/src/test/java/com/example/swapit/service/GoodServiceTest.java
@@ -23,6 +23,7 @@ import com.example.swapit.domain.dto.GoodsRequestDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.ReviewRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GoodServiceTest {
@@ -38,6 +39,9 @@ class GoodServiceTest {
 
 	@Mock
 	private CurrentUserService currentUserService;
+
+	@Mock
+	private ReviewRepository reviewRepository;
 
 	@InjectMocks
 	private GoodsServiceImpl goodsService;
@@ -77,6 +81,7 @@ class GoodServiceTest {
 	void getGoodDetail() {
 		// given
 		when(goodsRepository.findById(1L)).thenReturn(Optional.of(testGood));
+		when(reviewRepository.averageRatingByReviewee(testUser)).thenReturn(4.8);
 
 		// when
 		GoodsDetailDto result = goodsService.getGoodDetail(1L);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #74 

## 📝 작업 내용
- 간단한 유저 프로필 DTO(UserProfileDto)에 유저 프로필 이미지 추가
- 리뷰 평점 평균도 단순 0.0 주입하는 로직에서, 구현한 reviews에서 가져와 주입하는 방식으로 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
hotfix여서 빠르게 머지하겠습니다! 이후에 리뷰 남겨주시면 확인하겠습니다!