### PR TITLE
[hotfix] 프로필이미지 url 연결 안되는 오류 수정 및 Trades 엔티티 수정

### DIFF
--- a/src/main/java/com/example/swapit/controller/UserController.java
+++ b/src/main/java/com/example/swapit/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
 	}
 
 	@GetMapping("/all/auth/info/{userId}")
-	public ApiResponse<UserPageDto> getAnotherUserPage(@PathVariable Long userId) {
+	public ApiResponse<UserPageDto> getAnotherUserPage(@PathVariable("userId") Long userId) {
 		return ApiResponse.success(usersService.getAnotherUserPage(userId));
 	}
 

--- a/src/main/java/com/example/swapit/domain/Goods.java
+++ b/src/main/java/com/example/swapit/domain/Goods.java
@@ -3,6 +3,7 @@ package com.example.swapit.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -20,11 +21,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -61,6 +57,7 @@ public class Goods extends BaseEntity {
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
+	@Setter
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private GoodsTradeStatus goodsTradeStatus;

--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -50,19 +50,9 @@ public class Trades extends BaseEntity {
 	@JoinColumn(name = "target_goods_id", nullable = false)
 	private Goods targetGoods;
 
-	@ManyToOne
-	@JoinColumn(name = "requester_id", nullable = false)
-	private Users requester;
-
-	@ManyToOne
-	@JoinColumn(name = "owner_id", nullable = false)
-	private Users owner;
-
 	public Trades(Goods requestedGoods, Goods targetGoods) {
 		this.status = TradeStatus.PENDING;
 		this.requestedGoods = requestedGoods;
 		this.targetGoods = targetGoods;
-		this.requester = requestedGoods.getUser();
-		this.owner = targetGoods.getUser();
 	}
 }

--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -1,5 +1,6 @@
 package com.example.swapit.domain;
 
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -28,7 +29,7 @@ import lombok.Setter;
 @SQLDelete(sql = "UPDATE trades SET is_deleted = true WHERE trades_id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "trades",
-	uniqueConstraints = @UniqueConstraint(columnNames = {"target_goods_id, requester_id"})
+	uniqueConstraints = @UniqueConstraint(columnNames = {"target_goods_id, requested_goods_id"})
 )
 public class Trades extends BaseEntity {
 
@@ -49,6 +50,12 @@ public class Trades extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "target_goods_id", nullable = false)
 	private Goods targetGoods;
+
+	@Formula("(SELECT g.users_id FROM goods g WHERE g.goods_id = requested_goods_id)")
+	private Long requesterId;
+
+	@Formula("(SELECT g.users_id FROM goods g WHERE g.goods_id = target_goods_id)")
+	private Long ownerId;
 
 	public Trades(Goods requestedGoods, Goods targetGoods) {
 		this.status = TradeStatus.PENDING;

--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -51,12 +51,6 @@ public class Trades extends BaseEntity {
 	@JoinColumn(name = "target_goods_id", nullable = false)
 	private Goods targetGoods;
 
-	@Formula("(SELECT g.users_id FROM goods g WHERE g.goods_id = requested_goods_id)")
-	private Long requesterId;
-
-	@Formula("(SELECT g.users_id FROM goods g WHERE g.goods_id = target_goods_id)")
-	private Long ownerId;
-
 	public Trades(Goods requestedGoods, Goods targetGoods) {
 		this.status = TradeStatus.PENDING;
 		this.requestedGoods = requestedGoods;

--- a/src/main/java/com/example/swapit/domain/dto/UserPageDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserPageDto.java
@@ -21,5 +21,6 @@ public class UserPageDto {
 	private long totalGoodsCount;
 	private long completedSwapCount;
 	private double ratingAverage;
+	private long totalReviewCount;
 	private List<ReviewDto> reviews;
 }

--- a/src/main/java/com/example/swapit/repository/GoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/GoodsRepository.java
@@ -2,6 +2,7 @@ package com.example.swapit.repository;
 
 import java.util.List;
 
+import com.example.swapit.domain.GoodsTradeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.swapit.domain.Goods;
@@ -12,4 +13,6 @@ public interface GoodsRepository extends JpaRepository<Goods, Long>, CustomGoods
 	List<Goods> findByUserOrderByCreatedAtDesc(Users user);
 
 	long countByUser(Users user);
+
+	long countByUserAndGoodsTradeStatus(Users user, GoodsTradeStatus goodsTradeStatus);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -14,7 +14,7 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 	List<Reviews> findAllByRevieweeOrderByCreatedAtDesc(Users reviewee);
 
 	@Query("SELECT COALESCE(AVG(r.rating), 0.0) FROM Reviews r WHERE r.reviewee = :reviewee")
-	Double averageRatingByReviewee(@Param("reviewee") Users reviewee);
+	double averageRatingByReviewee(@Param("reviewee") Users reviewee);
 
-	List<Reviews> findTop3ByRevieweeOrderByCreatedAtDesc(Users reviewee);
+	List<Reviews> findTop5ByRevieweeOrderByCreatedAtDesc(Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -17,4 +17,6 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 	double averageRatingByReviewee(@Param("reviewee") Users reviewee);
 
 	List<Reviews> findTop5ByRevieweeOrderByCreatedAtDesc(Users reviewee);
+
+	long countByReviewee(Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -2,6 +2,7 @@ package com.example.swapit.repository;
 
 import java.util.List;
 
+import com.example.swapit.domain.TradeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,9 +18,6 @@ import io.lettuce.core.dynamic.annotation.Param;
 public interface TradesRepository extends JpaRepository<Trades, Long> {
 	long countByTargetGoodsIdAndIsDeletedFalse(Long goodsId);
 
-	@Query("SELECT COUNT(*) FROM Trades t WHERE ( t.owner = :user OR t.requester = :user ) AND t.status = 'COMPLETED'")
-	long countByCompletedTradesByUser(@Param("user") Users user);
-
 	@Modifying
 	@Query("UPDATE Trades t SET t.status = 'REJECTED' WHERE t.targetGoods = :targetGoods AND t.id <> :acceptedTradeId")
 	void rejectOtherTrades(@Param("targetGoods") Goods targetGoods, @Param("acceptedTradeId") Long acceptedTradeId);
@@ -32,7 +30,7 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 
 	@Query("SELECT new com.example.swapit.domain.dto.trade.RequestGoodsImageDto(t.targetGoods, t.requestedGoods) "
 		+ "FROM Trades t "
-		+ "WHERE t.requester.id = :userId")
+		+ "WHERE t.requesterId = :userId")
 	List<RequestGoodsImageDto> findMyRequests(@Param("userId") Long userId);
 
 	@Query("SELECT t.requestedGoods FROM Trades t WHERE t.targetGoods.id = :goodsId")

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -30,7 +30,7 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 
 	@Query("SELECT new com.example.swapit.domain.dto.trade.RequestGoodsImageDto(t.targetGoods, t.requestedGoods) "
 		+ "FROM Trades t "
-		+ "WHERE t.requesterId = :userId")
+		+ "WHERE t.requestedGoods.user.usersId = :userId")
 	List<RequestGoodsImageDto> findMyRequests(@Param("userId") Long userId);
 
 	@Query("SELECT t.requestedGoods FROM Trades t WHERE t.targetGoods.id = :goodsId")

--- a/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
@@ -42,10 +42,10 @@ public class ReviewServiceImpl implements ReviewService {
 
 		// 리뷰 대상자 설정
 		Users reviewee;
-		if (trade.getRequester().getUsersId().equals(writer.getUsersId())) {
-			reviewee = trade.getOwner(); // 요청자가 작성하는 경우 -> 리뷰 대상자는 소유자
-		} else if (trade.getOwner().getUsersId().equals(writer.getUsersId())) {
-			reviewee = trade.getRequester(); // 소유자가 작성하는 경우 -> 리뷰 대상자는 요청자
+		if (trade.getRequesterId().equals(writer.getUsersId())) {
+			reviewee = trade.getTargetGoods().getUser(); // 요청자가 작성하는 경우 -> 리뷰 대상자는 소유자
+		} else if (trade.getOwnerId().equals(writer.getUsersId())) {
+			reviewee = trade.getRequestedGoods().getUser(); // 소유자가 작성하는 경우 -> 리뷰 대상자는 요청자
 		} else {
 			throw new CustomException(ErrorCode.REVIEW_UNAUTHORIZED_ACCESS);
 		}

--- a/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
@@ -42,9 +42,9 @@ public class ReviewServiceImpl implements ReviewService {
 
 		// 리뷰 대상자 설정
 		Users reviewee;
-		if (trade.getRequesterId().equals(writer.getUsersId())) {
+		if (trade.getRequestedGoods().getUser().getUsersId().equals(writer.getUsersId())) {
 			reviewee = trade.getTargetGoods().getUser(); // 요청자가 작성하는 경우 -> 리뷰 대상자는 소유자
-		} else if (trade.getOwnerId().equals(writer.getUsersId())) {
+		} else if (trade.getTargetGoods().getUser().getUsersId().equals(writer.getUsersId())) {
 			reviewee = trade.getRequestedGoods().getUser(); // 소유자가 작성하는 경우 -> 리뷰 대상자는 요청자
 		} else {
 			throw new CustomException(ErrorCode.REVIEW_UNAUTHORIZED_ACCESS);

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -76,7 +76,9 @@ public class TradesServiceImpl implements TradesService {
 			.orElseThrow(() -> new CustomException(ErrorCode.TRADES_NOT_FOUND));
 
 		// 거래 owner 인지 검증
-		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getTargetGoods().getUser().getUsersId())) {
+		if (!currentUserService.getCurrentUser().getUsersId().equals(
+				trades.getTargetGoods().getUser().getUsersId())
+		) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -93,7 +95,9 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생
 		notificationEventPublisher.publishNotification(
-			trades.getRequesterId(), NotificationType.ACCEPTED, trades.getTargetGoods().getId()
+			trades.getRequestedGoods().getUser().getUsersId(),
+			NotificationType.ACCEPTED,
+			trades.getTargetGoods().getId()
 		);
 	}
 
@@ -104,7 +108,7 @@ public class TradesServiceImpl implements TradesService {
 			.orElseThrow(() -> new CustomException(ErrorCode.TRADES_NOT_FOUND));
 
 		// 거래 owner 인지 검증
-		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getOwnerId())) {
+		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getTargetGoods().getUser().getUsersId())) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -112,7 +116,9 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생
 		notificationEventPublisher.publishNotification(
-			trades.getRequesterId(), NotificationType.REJECTED, trades.getTargetGoods().getId()
+			trades.getRequestedGoods().getUser().getUsersId(),
+				NotificationType.REJECTED,
+				trades.getTargetGoods().getId()
 		);
 	}
 
@@ -126,7 +132,8 @@ public class TradesServiceImpl implements TradesService {
 		Long userId = user.getUsersId();
 
 		// 거래 관계자인지 확인
-		if (!userId.equals(trade.getOwnerId()) && !userId.equals(trade.getRequesterId())) {
+		if (!userId.equals(trade.getTargetGoods().getUser().getUsersId())
+				&& !userId.equals(trade.getRequestedGoods().getUser().getUsersId())) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -141,7 +148,7 @@ public class TradesServiceImpl implements TradesService {
 		goodsRepository.save(trade.getRequestedGoods());
 
 		// 거래 상대방에게 알림 전송
-		Users recipient = (userId.equals(trade.getOwnerId()))
+		Users recipient = (userId.equals(trade.getTargetGoods().getUser().getUsersId()))
 				? trade.getRequestedGoods().getUser() : trade.getTargetGoods().getUser();
 		notificationEventPublisher.publishNotification(
 			recipient.getUsersId(), NotificationType.COMPLETED

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -85,6 +85,12 @@ public class TradesServiceImpl implements TradesService {
 		// 같은 물건의 다른 거래 요청을 모두 REJECTED로 변경
 		tradesRepository.rejectOtherTrades(trades.getTargetGoods(), tradesId);
 
+		// 각 물건 상태를 reserved로 변경
+		trades.getTargetGoods().setGoodsTradeStatus(GoodsTradeStatus.RESERVED);
+		goodsRepository.save(trades.getTargetGoods());
+		trades.getRequestedGoods().setGoodsTradeStatus(GoodsTradeStatus.RESERVED);
+		goodsRepository.save(trades.getRequestedGoods());
+
 		// 알림 발생
 		notificationEventPublisher.publishNotification(
 			trades.getRequesterId(), NotificationType.ACCEPTED, trades.getTargetGoods().getId()
@@ -130,7 +136,9 @@ public class TradesServiceImpl implements TradesService {
 
 		// 각 물건 거래 상태도 sold out 처리
 		trade.getTargetGoods().setGoodsTradeStatus(GoodsTradeStatus.SOLDOUT);
+		goodsRepository.save(trade.getTargetGoods());
 		trade.getRequestedGoods().setGoodsTradeStatus(GoodsTradeStatus.SOLDOUT);
+		goodsRepository.save(trade.getRequestedGoods());
 
 		// 거래 상대방에게 알림 전송
 		Users recipient = (userId.equals(trade.getOwnerId()))

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -81,7 +81,7 @@ public class TradesServiceImpl implements TradesService {
 			.orElseThrow(() -> new CustomException(ErrorCode.TRADES_NOT_FOUND));
 
 		// 거래 owner 인지 검증
-		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getOwner().getUsersId())) {
+		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getTargetGoods().getUser().getUsersId())) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -92,7 +92,7 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생
 		notificationEventPublisher.publishNotification(
-			trades.getRequester().getUsersId(), NotificationType.ACCEPTED, trades.getTargetGoods().getId()
+			trades.getRequesterId(), NotificationType.ACCEPTED, trades.getTargetGoods().getId()
 		);
 	}
 
@@ -103,7 +103,7 @@ public class TradesServiceImpl implements TradesService {
 			.orElseThrow(() -> new CustomException(ErrorCode.TRADES_NOT_FOUND));
 
 		// 거래 owner 인지 검증
-		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getOwner().getUsersId())) {
+		if (!currentUserService.getCurrentUser().getUsersId().equals(trades.getOwnerId())) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -111,7 +111,7 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생
 		notificationEventPublisher.publishNotification(
-			trades.getRequester().getUsersId(), NotificationType.REJECTED, trades.getTargetGoods().getId()
+			trades.getRequesterId(), NotificationType.REJECTED, trades.getTargetGoods().getId()
 		);
 	}
 
@@ -125,7 +125,7 @@ public class TradesServiceImpl implements TradesService {
 		Long userId = user.getUsersId();
 
 		// 거래 관계자인지 확인
-		if (!userId.equals(trade.getOwner().getUsersId()) && !userId.equals(trade.getRequester().getUsersId())) {
+		if (!userId.equals(trade.getOwnerId()) && !userId.equals(trade.getRequesterId())) {
 			throw new CustomException(ErrorCode.TRADE_UNAUTHORIZED);
 		}
 
@@ -134,7 +134,8 @@ public class TradesServiceImpl implements TradesService {
 		tradesRepository.save(trade);
 
 		// 거래 상대방에게 알림 전송
-		Users recipient = (userId.equals(trade.getOwner().getUsersId())) ? trade.getRequester() : trade.getOwner();
+		Users recipient = (userId.equals(trade.getOwnerId()))
+				? trade.getRequestedGoods().getUser() : trade.getTargetGoods().getUser();
 		notificationEventPublisher.publishNotification(
 			recipient.getUsersId(), NotificationType.COMPLETED
 		);

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -4,17 +4,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.example.swapit.domain.*;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
-import com.example.swapit.domain.Goods;
-import com.example.swapit.domain.GoodsImages;
-import com.example.swapit.domain.NotificationType;
-import com.example.swapit.domain.TradeStatus;
-import com.example.swapit.domain.Trades;
-import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.trade.MyGoodsDto;
 import com.example.swapit.domain.dto.trade.MyRequestDto;
 import com.example.swapit.domain.dto.trade.ReceivedRequestDto;
@@ -132,6 +127,10 @@ public class TradesServiceImpl implements TradesService {
 		// 거래 완료 처리
 		trade.setStatus(TradeStatus.COMPLETED);
 		tradesRepository.save(trade);
+
+		// 각 물건 거래 상태도 sold out 처리
+		trade.getTargetGoods().setGoodsTradeStatus(GoodsTradeStatus.SOLDOUT);
+		trade.getRequestedGoods().setGoodsTradeStatus(GoodsTradeStatus.SOLDOUT);
 
 		// 거래 상대방에게 알림 전송
 		Users recipient = (userId.equals(trade.getOwnerId()))

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -42,10 +42,11 @@ public class UsersServiceImpl implements UsersService {
 		long totalUsersGoodsCount = goodsRepository.countByUser(user);
 		long completedSwapCount = goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT);
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
-		List<ReviewDto> reviews = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
+		List<ReviewDto> reviewsTop5 = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
 			.map(ReviewDto::of)
 			.toList();
+		long totalReviewCount = reviewRepository.countByReviewee(user);
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
@@ -55,7 +56,7 @@ public class UsersServiceImpl implements UsersService {
 
 		return new UserPageDto(
 			user.getUsersId(), user.getNickname(), user.getEmail(), profileImageUrl,
-			totalUsersGoodsCount, completedSwapCount, averageRating, reviews
+			totalUsersGoodsCount, completedSwapCount, averageRating, totalReviewCount, reviewsTop5
 		);
 	}
 
@@ -67,10 +68,11 @@ public class UsersServiceImpl implements UsersService {
 		long totalUsersGoodsCount = goodsRepository.countByUser(user);
 		long completedSwapCount = goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT);
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
-		List<ReviewDto> reviews = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
+		List<ReviewDto> reviewsRecentlyTop5 = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
 			.map(ReviewDto::of)
 			.toList();
+		long totalReviewCount = reviewRepository.countByReviewee(user);
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
@@ -80,7 +82,7 @@ public class UsersServiceImpl implements UsersService {
 
 		return new UserPageDto(
 			user.getUsersId(), user.getNickname(), null, profileImageUrl,
-			totalUsersGoodsCount, completedSwapCount, averageRating, reviews
+			totalUsersGoodsCount, completedSwapCount, averageRating, totalReviewCount, reviewsRecentlyTop5
 		);
 	}
 

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -20,7 +20,6 @@ import com.example.swapit.domain.dto.UserPageDto;
 import com.example.swapit.repository.FcmTokenRepository;
 import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -33,7 +32,6 @@ public class UsersServiceImpl implements UsersService {
 	private final AwsS3Service awsS3Service;
 	private final UsersRepository usersRepository;
 	private final GoodsRepository goodsRepository;
-	private final TradesRepository tradesRepository;
 	private final ReviewRepository reviewRepository;
 	private final FcmTokenRepository fcmTokenRepository;
 

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.swapit.service;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.swapit.domain.GoodsTradeStatus;
+import com.example.swapit.domain.TradeStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,7 +26,6 @@ import com.example.swapit.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class UsersServiceImpl implements UsersService {
 
@@ -37,21 +38,20 @@ public class UsersServiceImpl implements UsersService {
 	private final FcmTokenRepository fcmTokenRepository;
 
 	@Override
-	@Transactional(readOnly = true)
 	public UserPageDto getMyPage() {
 		Users user = currentUserService.getCurrentUser();
 
 		long totalUsersGoodsCount = goodsRepository.countByUser(user);
-		long completedSwapCount = tradesRepository.countByCompletedTradesByUser(user);
+		long completedSwapCount = goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT);
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
-		List<ReviewDto> reviews = reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)
+		List<ReviewDto> reviews = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
 			.map(ReviewDto::of)
 			.toList();
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
-		if(profileImageUrl.startsWith("images/users/")) {
+		if(profileImageUrl.startsWith("images/")) {
 			profileImageUrl = awsS3Service.generatePreSignedImageUrl(profileImageUrl);
 		}
 
@@ -67,16 +67,16 @@ public class UsersServiceImpl implements UsersService {
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		long totalUsersGoodsCount = goodsRepository.countByUser(user);
-		long completedSwapCount = tradesRepository.countByCompletedTradesByUser(user);
+		long completedSwapCount = goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT);
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
-		List<ReviewDto> reviews = reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)
+		List<ReviewDto> reviews = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
 			.map(ReviewDto::of)
 			.toList();
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
-		if(profileImageUrl.startsWith("images/users/")) {
+		if(profileImageUrl.startsWith("images/")) {
 			profileImageUrl = awsS3Service.generatePreSignedImageUrl(profileImageUrl);
 		}
 
@@ -87,12 +87,14 @@ public class UsersServiceImpl implements UsersService {
 	}
 
 	@Override
+	@Transactional
 	public void updateProfileImage(MultipartFile file) {
 		Users user = currentUserService.getCurrentUser();
 		user.updateProfileImageUrl(awsS3Service.updateUserProfileImage(user, file));
 	}
 
 	@Override
+	@Transactional
 	public void updateNickname(UserNicknameDto dto) {
 		Users user = currentUserService.getCurrentUser();
 		user.updateNickname(dto.getNickname());
@@ -100,6 +102,7 @@ public class UsersServiceImpl implements UsersService {
 	}
 
 	@Override
+	@Transactional
 	public void updateFcmToken(FcmTokenDto dto) {
 		Users user = currentUserService.getCurrentUser();
 

--- a/src/test/java/com/example/swapit/controller/UserControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/UserControllerTest.java
@@ -46,7 +46,7 @@ class UserControllerTest {
 		userPageDto = new UserPageDto(
 			1L, "testUser", "test@example.com",
 			"https://profile.img", 10L, 5L, 4.5,
-			List.of()  // 리뷰 리스트는 비워둠
+				0L, List.of()  // 리뷰 리스트는 비워둠
 		);
 	}
 

--- a/src/test/java/com/example/swapit/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ReviewServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.swapit.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +18,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
-import com.example.swapit.domain.Reviews;
-import com.example.swapit.domain.TradeStatus;
-import com.example.swapit.domain.Trades;
-import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ReviewListDto;
 import com.example.swapit.domain.dto.ReviewRequestDto;
 import com.example.swapit.repository.ReviewRepository;
@@ -43,6 +40,8 @@ class ReviewServiceTest {
 
 	private Users writer;
 	private Users owner;
+	private Goods requestedGoods;
+	private Goods targetGoods;
 	private Trades completedTrade;
 	private Trades inProgressTrade;
 	private ReviewRequestDto reviewRequestDto;
@@ -53,17 +52,20 @@ class ReviewServiceTest {
 		writer = Users.builder().usersId(1L).build();
 		owner = Users.builder().usersId(2L).build();
 
+		requestedGoods = Goods.builder().user(writer).build();
+		targetGoods = Goods.builder().user(owner).build();
+
 		completedTrade = Trades.builder()
 			.id(1L)
-			.requester(writer)
-			.owner(owner)
+			.requestedGoods(requestedGoods)
+			.targetGoods(targetGoods)
 			.status(TradeStatus.COMPLETED) // 거래 완료 상태
 			.build();
 
 		inProgressTrade = Trades.builder()
 			.id(2L)
-			.requester(writer)
-			.owner(owner)
+			.requestedGoods(requestedGoods)
+			.targetGoods(targetGoods)
 			.status(TradeStatus.INPROGRESS) // 거래 진행 중 상태
 			.build();
 

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -205,8 +205,6 @@ public class TradesServiceTest {
 			.build();
 		Trades trade = Trades.builder()
 			.id(1L)
-			.owner(target)
-			.requester(requester)
 			.targetGoods(targetGood)
 			.requestedGoods(requestedGood)
 			.status(TradeStatus.PENDING)
@@ -227,59 +225,56 @@ public class TradesServiceTest {
 	@Test
 	@DisplayName("거래 수락 성공 - 다른 거래들 거절 되었는지 확인")
 	void acceptTrade_ShouldRejectAllOtherTrades() {
-		// Given
+		// given
 		Long acceptedTradeId = 1L;
-		Goods targetGood = Goods.builder()
-			.build();
-		Users target = Users.builder()
-			.usersId(1L)
-			.build();
-		Users requester1 = Users.builder()
-			.usersId(2L)
-			.build();
-		Users requester2 = Users.builder()
-			.usersId(3L)
-			.build();
-		Users requester3 = Users.builder()
-			.usersId(4L)
-			.build();
+
+		Users target = Users.builder().usersId(1L).build();
+
+		Users requester1 = Users.builder().usersId(2L).build();
+		Users requester2 = Users.builder().usersId(3L).build();
+		Users requester3 = Users.builder().usersId(4L).build();
+
+		Goods targetGood = Goods.builder().user(target).build();
+		Goods requestedGood1 = Goods.builder().user(requester1).build();
+		Goods requestedGood2 = Goods.builder().user(requester2).build();
+		Goods requestedGood3 = Goods.builder().user(requester3).build();
 
 		// 1. 거래 리스트 (거래를 요청한 사용자 3명)
 		Trades acceptedTrade = Trades.builder()
-			.id(acceptedTradeId)
-			.owner(target)
-			.requester(requester1)
-			.targetGoods(targetGood)
-			.build();
+				.id(acceptedTradeId)
+				.targetGoods(targetGood)
+				.requestedGoods(requestedGood1)
+				.build();
 
 		Trades otherTrade1 = Trades.builder()
-			.id(2L)
-			.requester(requester2)
-			.targetGoods(targetGood)
-			.build();
+				.id(2L)
+				.targetGoods(targetGood)
+				.requestedGoods(requestedGood2)
+				.build();
+
 		Trades otherTrade2 = Trades.builder()
-			.id(3L)
-			.requester(requester3)
-			.targetGoods(targetGood)
-			.build();
+				.id(3L)
+				.targetGoods(targetGood)
+				.requestedGoods(requestedGood3)
+				.build();
 
 		List<Trades> pendingTrades = Arrays.asList(acceptedTrade, otherTrade1, otherTrade2);
 
 		when(tradesRepository.findById(acceptedTradeId)).thenReturn(Optional.of(acceptedTrade));
 		when(currentUserService.getCurrentUser()).thenReturn(target);
 
-		// 3. Mock 설정: rejectOtherTrades() 호출 시 상태 변경 로직을 직접 수행
+		// Mock 설정: rejectOtherTrades() 호출 시 상태 변경 로직을 직접 수행
 		doAnswer(invocation -> {
 			Goods myTargetGood = invocation.getArgument(0);
 			Long excludedTradeId = invocation.getArgument(1);
 
 			// 다른 거래 요청들을 모두 REJECTED 상태로 변경
 			pendingTrades.stream()
-				.filter(
-					trade -> trade.getTargetGoods().equals(myTargetGood) && !trade.getId().equals(excludedTradeId))
-				.forEach(trade -> trade.setStatus(TradeStatus.REJECTED));
+					.filter(trade -> trade.getTargetGoods().equals(myTargetGood) && !trade.getId().equals(excludedTradeId))
+					.forEach(trade -> trade.setStatus(TradeStatus.REJECTED));
 			return null;
 		}).when(tradesRepository).rejectOtherTrades(targetGood, acceptedTradeId);
+
 
 		// When
 		tradesService.acceptTrade(acceptedTradeId);
@@ -350,10 +345,8 @@ public class TradesServiceTest {
 			.build();
 		Trades trade = Trades.builder()
 			.id(1L)
-			.owner(target)
 			.targetGoods(targetGood)
 			.requestedGoods(requestedGood)
-			.requester(requester)
 			.status(TradeStatus.PENDING)
 			.build();
 

--- a/src/test/java/com/example/swapit/service/UsersServiceTest.java
+++ b/src/test/java/com/example/swapit/service/UsersServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.swapit.domain.GoodsTradeStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,9 +41,6 @@ class UsersServiceTest {
 	private GoodsRepository goodsRepository;
 
 	@Mock
-	private TradesRepository tradesRepository;
-
-	@Mock
 	private ReviewRepository reviewRepository;
 
 	@Mock
@@ -67,9 +65,9 @@ class UsersServiceTest {
 		// given
 		when(currentUserService.getCurrentUser()).thenReturn(user);
 		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
-		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
+		when(goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT)).thenReturn(3L); // 거래 완료 3개
 		when(reviewRepository.averageRatingByReviewee(user)).thenReturn(4.5); // 평균 평점 4.5
-		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
+		when(reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
 
 		// when
 		UserPageDto result = usersService.getMyPage();
@@ -91,9 +89,9 @@ class UsersServiceTest {
 		Users currentUser = Users.builder().usersId(2L).build();
 		when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
 		when(goodsRepository.countByUser(user)).thenReturn(5L); // 상품 5개
-		when(tradesRepository.countByCompletedTradesByUser(user)).thenReturn(3L); // 거래 완료 3개
+		when(goodsRepository.countByUserAndGoodsTradeStatus(user, GoodsTradeStatus.SOLDOUT)).thenReturn(3L); // 거래 완료 3개
 		when(reviewRepository.averageRatingByReviewee(user)).thenReturn(4.5); // 평균 평점 4.5
-		when(reviewRepository.findTop3ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
+		when(reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)).thenReturn(List.of());
 
 		// when
 		UserPageDto result = usersService.getAnotherUserPage(1L);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#82 

## 📝 작업 내용
- 마이페이지 : 서버에서 저장한 이미지인지 확인하고, 맞으면 s3 의 presigned image url로 변환해서 반환.
  - 마이페이지 최신 리뷰 5개 리스트로 내려주기
  - 총 리뷰 개수 응답에 넣어서 반환
- 거래 완료된 물건 개수를 trades에서 조회하지 않고, goods에서 조회하는 로직으로 변경
  - 거래에서 수락할 때, 각각의 물건들이 "RESERVED"상태로 바뀌고, 거래를 완료하면 "SOLDOUT"으로 바뀌는 것으로 변경.
- Trades 엔티티에서 requester, owner 제거
  - 그에 맞게 테스트 코드도 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
x
