### PR TITLE
[FEAT] image url 을 s3 -> cloud front 도메인에 연결

### DIFF
--- a/src/main/java/com/example/swapit/domain/Users.java
+++ b/src/main/java/com/example/swapit/domain/Users.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Builder
@@ -28,9 +29,11 @@ public class Users {
 	@Column(name = "users_id", columnDefinition = "BIGINT", nullable = false)
 	private Long usersId;
 
+	@Setter
 	@Column(name = "nickname", columnDefinition = "VARCHAR(20)", nullable = false)
 	private String nickname;
 
+	@Setter
 	@Column(name = "profile_image_url", columnDefinition = "TEXT", nullable = false)
 	private String profileImageUrl;
 
@@ -50,12 +53,4 @@ public class Users {
 	@Builder.Default
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Notifications> notificationsList = new ArrayList<>();
-
-	public void updateProfileImageUrl(String profileImageUrl) {
-		this.profileImageUrl = profileImageUrl;
-	}
-
-	public void updateNickname(String nickname) {
-		this.nickname = nickname;
-	}
 }

--- a/src/main/java/com/example/swapit/domain/dto/ReviewDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/ReviewDto.java
@@ -21,11 +21,11 @@ public class ReviewDto {
 	private String content;
 	private LocalDateTime createdAt;
 
-	public static ReviewDto of(Reviews review) {
+	public static ReviewDto of(Reviews review, String writerProfileImageUrl) {
 		return ReviewDto.builder()
 			.usersId(review.getWriter().getUsersId())
 			.nickname(review.getWriter().getNickname())
-			.profileImageUrl(review.getWriter().getProfileImageUrl())
+			.profileImageUrl(writerProfileImageUrl)
 			.rating(review.getRating())
 			.content(review.getContent())
 			.createdAt(review.getCreatedAt())

--- a/src/main/java/com/example/swapit/domain/dto/UserNicknameDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserNicknameDto.java
@@ -3,8 +3,10 @@ package com.example.swapit.domain.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserNicknameDto {
 	@NotBlank(message = "닉네임은 필수 입력 값입니다.")

--- a/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/UserProfileDto.java
@@ -16,11 +16,11 @@ public class UserProfileDto {
 	private String profileImageUrl;
 	private Double userRating;
 
-	public static UserProfileDto of(Users user, Double averageRating) {
+	public static UserProfileDto of(Users user, String userProfileImageUrl, Double averageRating) {
 		return UserProfileDto.builder()
 			.userId(user.getUsersId())
 			.nickname(user.getNickname())
-			.profileImageUrl(user.getProfileImageUrl())
+			.profileImageUrl(userProfileImageUrl)
 			.userRating(averageRating)
 			.build();
 	}

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -31,7 +31,6 @@ public class AuthServiceImpl implements AuthService {
 	private final UsersRepository usersRepository;
 	private final TokensRepository tokensRepository;
 	private final RestTemplate restTemplate;
-	private final AwsS3Service awsS3Service;
 
 	@Override
 	public TokenDTO refresh(String token) {
@@ -75,7 +74,7 @@ public class AuthServiceImpl implements AuthService {
 			return UserResponseDTO.builder()
 				.nickname(user.getNickname())
 				.email(user.getEmail())
-				.profileImgUrl(awsS3Service.generatePreSignedImageUrl(user.getProfileImageUrl()))
+				.profileImgUrl(user.getProfileImageUrl())
 				.loginInfo(user.getLoginInfo())
 				.build();
 		} catch (CustomException ce) {

--- a/src/main/java/com/example/swapit/service/AwsS3Service.java
+++ b/src/main/java/com/example/swapit/service/AwsS3Service.java
@@ -12,8 +12,6 @@ import com.example.swapit.domain.Users;
 public interface AwsS3Service {
 	List<Pair<String, String>> uploadFiles(Goods good, List<MultipartFile> files);
 
-	String generatePreSignedImageUrl(String objectKey);
-
 	void deleteFile(GoodsImages image);
 
 	String updateUserProfileImage(Users user, MultipartFile file);

--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -33,6 +33,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	private String bucketName;
 
 	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png"); // 이미지 가능 확장자
+	private final String baseUrl = "images/";
 	private final S3Client s3Client;
 
 	/**
@@ -45,7 +46,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 				if (!isValidImageFile(file.getOriginalFilename())) {
 					throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
 				}
-				String s3Key = uploadFileToS3(file, "images/goods/" + good.getId());
+				String s3Key = uploadFileToS3(file, "goods/" + good.getId());
 				return Pair.of(s3Key, file.getContentType());
 			}).toList();
 	}
@@ -53,19 +54,14 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	@Override
 	public void deleteFile(GoodsImages image) {
 		// S3에서 이미지 삭제
-		deleteFileFromS3(image.getS3Key());
+		deleteFileFromS3(baseUrl + image.getS3Key());
 	}
 
 	@Override
 	public String updateUserProfileImage(Users user, MultipartFile file) {
 		isValidImageFile(file.getOriginalFilename());
-
-		// 기존 프로필 이미지 삭제 (있다면)
-		if (user.getProfileImageUrl() != null) {
-			deleteFileFromS3(user.getProfileImageUrl()); // 기존 이미지 삭제
-		}
-
-		return uploadFileToS3(file, "images/users/" + user.getUsersId());
+		deleteFileFromS3(user.getProfileImageUrl()); // 기존 이미지 삭제
+		return uploadFileToS3(file, "users/" + user.getUsersId());
 	}
 
 	/**
@@ -78,7 +74,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 		try {
 			PutObjectRequest putRequest = PutObjectRequest.builder()
 				.bucket(bucketName)
-				.key(s3Key)
+				.key(baseUrl + s3Key)
 				.contentType(file.getContentType())
 				.build();
 
@@ -100,7 +96,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	private void deleteFileFromS3(String s3Key) {
 		DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
 			.bucket(bucketName)
-			.key(s3Key)
+			.key(baseUrl + s3Key)
 			.build();
 
 		s3Client.deleteObject(deleteObjectRequest);

--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.swapit.service;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,9 +22,6 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Slf4j
 @Service
@@ -37,10 +33,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	private String bucketName;
 
 	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png"); // 이미지 가능 확장자
-	private static final int IMAGE_SHOW_TIME_LIMIT = 10; // 이미지 링크 유지 시간 (10분)
-
 	private final S3Client s3Client;
-	private final S3Presigner s3Presigner;
 
 	/**
 	 * 이미지 업로드
@@ -55,22 +48,6 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 				String s3Key = uploadFileToS3(file, "images/goods/" + good.getId());
 				return Pair.of(s3Key, file.getContentType());
 			}).toList();
-	}
-
-	/**
-	 * 단일 이미지 조회 : Pre-signed URL 생성
-	 *  todo : 버킷 이름이 보여서, CloudFront 도입
-	 */
-	@Override
-	public String generatePreSignedImageUrl(String objectKey) {
-		GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-			.signatureDuration(Duration.ofMinutes(IMAGE_SHOW_TIME_LIMIT))
-			.getObjectRequest(req -> req.bucket(bucketName).key(objectKey))
-			.build();
-
-		// todo : 앱 배포 시, 앱에서만 사용하도록 CustomHeader 추가.
-		PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
-		return presignedRequest.url().toString();
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.swapit.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +48,9 @@ public class ChatServiceImpl implements ChatService {
 	private final ChatsRepository chatRepository;
 	private final GoodsImagesRepository goodsImagesRepository;
 	private final NotificationEventPublisher notificationEventPublisher;
-	private final AwsS3Service awsS3Service;
+
+	@Value("${cloud.aws.cloudfront.url}")
+	private String cdnUrl;
 
 	private static final int size = 30;
 
@@ -120,12 +123,14 @@ public class ChatServiceImpl implements ChatService {
 
 				Users counterpart = usersRepository.findById(counterpartId)
 					.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+				String userProfileImageUrl = counterpart.getProfileImageUrl().trim().startsWith("http")
+					? counterpart.getProfileImageUrl() : cdnUrl + counterpart.getProfileImageUrl();
 
 				Chats chats = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId());
 
 				return ChatRoomResponseDto.builder()
 					.usersId(counterpartId)
-					.profileImageUrl(counterpart.getProfileImageUrl())
+					.profileImageUrl(userProfileImageUrl)
 					.nickname(counterpart.getNickname())
 					.recentChat(chats.getContent())
 					.recentChatTime(chats.getCreatedAt())
@@ -207,7 +212,7 @@ public class ChatServiceImpl implements ChatService {
 		Goods goods = chatRooms.getGoods();
 		String firstImageUrl = goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods)
 			.map(GoodsImages::getS3Key)
-			.map(awsS3Service::generatePreSignedImageUrl)
+			.map(s3Key -> cdnUrl + s3Key)
 			.orElse(null);
 
 		return new ChatRoomGoodsDto(

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.swapit.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,6 +42,9 @@ public class GoodsServiceImpl implements GoodsService {
 	private final ReviewRepository reviewRepository;
 	private final AwsS3Service awsS3Service;
 
+	@Value("${cloud.aws.cloudfront.url}")
+	private String cdnUrl;
+
 	private static final int size = 30;
 	private static final int MAX_IMAGES = 10; // 이미지 최대 개수
 
@@ -59,13 +63,13 @@ public class GoodsServiceImpl implements GoodsService {
 
 		// todo : 트래픽이 많아지면 Goods 엔티티에 "대표 이미지" 필드 추가
 		List<GoodsDto> goodsDtoList = paginateGoods.stream()
-			.map(good -> {
-				String firstImageUrl = goodsImagesRepository.findFirstByGoodOrderByIdAsc(good)
+			.map(good -> GoodsDto.of(
+				good,
+				goodsImagesRepository.findFirstByGoodOrderByIdAsc(good)
 					.map(GoodsImages::getS3Key)
-					.map(awsS3Service::generatePreSignedImageUrl)
-					.orElse(null);
-				return GoodsDto.of(good, firstImageUrl);
-			}).toList();
+					.map(s3Key -> cdnUrl + s3Key)
+					.orElse(null)
+			)).toList();
 
 		Long lastCursorId = paginateGoods.isEmpty() ? null : paginateGoods.get(paginateGoods.size() - 1).getId();
 
@@ -81,13 +85,13 @@ public class GoodsServiceImpl implements GoodsService {
 
 		// todo : 트래픽이 많아지면 Goods 엔티티에 "대표 이미지" 필드 추가
 		return findGoods.stream()
-			.map(good -> {
-				String firstImageUrl = goodsImagesRepository.findFirstByGoodOrderByIdAsc(good)
+			.map(good -> GoodsDto.of(
+				good,
+				goodsImagesRepository.findFirstByGoodOrderByIdAsc(good)
 					.map(GoodsImages::getS3Key)
-					.map(awsS3Service::generatePreSignedImageUrl)
-					.orElse(null);
-				return GoodsDto.of(good, firstImageUrl);
-			}).toList();
+					.map(s3Key -> cdnUrl + s3Key)
+					.orElse(null)
+			)).toList();
 	}
 
 	@Override
@@ -97,7 +101,11 @@ public class GoodsServiceImpl implements GoodsService {
 
 		// 유저 프로필 생성
 		Double averageRating = reviewRepository.averageRatingByReviewee(good.getUser());
-		UserProfileDto userProfileDto = UserProfileDto.of(good.getUser(), averageRating);
+		String profileImageUrl = good.getUser().getProfileImageUrl();
+		if (!profileImageUrl.trim().startsWith("http")) {
+			profileImageUrl = cdnUrl + profileImageUrl;
+		}
+		UserProfileDto userProfileDto = UserProfileDto.of(good.getUser(), profileImageUrl, averageRating);
 
 		// todo :  redis로 ip 제한 걸어서 30초 이내로 다시 요청할 때 변경 가능하도록 하능하게 하면 비기능 향상.
 		// 물건의 viewCount 증가 (새로고침할 때 viewCount가 무한히 증가됨. -> 이 부분은.)
@@ -106,9 +114,8 @@ public class GoodsServiceImpl implements GoodsService {
 		// 물건 이미지 리스트 조회
 		List<GoodsImageDto> photos = goodsImagesRepository.findByGood(good)
 			.stream()
-			.map(image -> new GoodsImageDto(image.getId(), awsS3Service.generatePreSignedImageUrl(image.getS3Key())))
+			.map(image -> new GoodsImageDto(image.getId(), cdnUrl + image.getS3Key()))
 			.toList();
-
 		return GoodsDetailDto.of(good, userProfileDto, photos);
 	}
 

--- a/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.swapit.service;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,9 @@ public class ReviewServiceImpl implements ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final TradesRepository tradesRepository;
 	private final CurrentUserService currentUserService;
+
+	@Value("${cloud.aws.cloudfront.url}")
+	private String cdnUrl;
 
 	@Override
 	public void createReview(ReviewRequestDto reviewRequestDto) {
@@ -74,7 +78,12 @@ public class ReviewServiceImpl implements ReviewService {
 		Users reviewee = currentUserService.getCurrentUser();
 		List<ReviewDto> reviewDtos = reviewRepository.findAllByRevieweeOrderByCreatedAtDesc(reviewee)
 			.stream()
-			.map(ReviewDto::of)
+			.map(review -> {
+				String profileImageUrl = review.getWriter().getProfileImageUrl().trim().startsWith("http")
+					? review.getWriter().getProfileImageUrl()
+					: cdnUrl + review.getWriter().getProfileImageUrl();
+				return ReviewDto.of(review, profileImageUrl);
+			})
 			.toList();
 
 		return new ReviewListDto(reviewDtos.size(), reviewDtos);

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +14,6 @@ import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.domain.ChatRooms;
 import com.example.swapit.domain.ChatType;
 import com.example.swapit.domain.Goods;
-import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.GoodsTradeStatus;
 import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.TradeStatus;
@@ -46,10 +46,13 @@ public class TradesServiceImpl implements TradesService {
 	private final GoodsImagesRepository goodsImagesRepository;
 	private final ChatRoomsRepository chatRoomsRepository;
 	private final CurrentUserService currentUserService;
-	private final AwsS3Service awsS3Service;
 	private final ChatNotificationService chatNotificationService;
 	private final NotificationEventPublisher notificationEventPublisher;
+
 	public static final int MAX_REQUEST_COUNT = 10;
+
+	@Value("${cloud.aws.cloudfront.url}")
+	private String cdnUrl;
 
 	@Override
 	@Transactional
@@ -304,8 +307,7 @@ public class TradesServiceImpl implements TradesService {
 
 	private String getFirstImageUrl(Goods goods) {
 		return goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods)
-			.map(GoodsImages::getS3Key)
-			.map(awsS3Service::generatePreSignedImageUrl)
+			.map(image -> cdnUrl + image.getS3Key())
 			.orElse(null);
 	}
 

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -3,8 +3,7 @@ package com.example.swapit.service;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.swapit.domain.GoodsTradeStatus;
-import com.example.swapit.domain.TradeStatus;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,6 +35,9 @@ public class UsersServiceImpl implements UsersService {
 	private final ReviewRepository reviewRepository;
 	private final FcmTokenRepository fcmTokenRepository;
 
+	@Value("${cloud.aws.cloudfront.url}")
+	private String cdnUrl;
+
 	@Override
 	public UserPageDto getMyPage() {
 		Users user = currentUserService.getCurrentUser();
@@ -45,14 +47,14 @@ public class UsersServiceImpl implements UsersService {
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
 		List<ReviewDto> reviewsTop5 = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
-			.map(ReviewDto::of)
+			.map(review -> ReviewDto.of(review, cdnUrl + review.getWriter().getProfileImageUrl()))
 			.toList();
 		long totalReviewCount = reviewRepository.countByReviewee(user);
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
-		if (!profileImageUrl.startsWith("http")) {
-			profileImageUrl = awsS3Service.generatePreSignedImageUrl(profileImageUrl.trim());
+		if (!profileImageUrl.trim().startsWith("http")) {
+			profileImageUrl = cdnUrl + profileImageUrl;
 		}
 
 		return new UserPageDto(
@@ -71,14 +73,14 @@ public class UsersServiceImpl implements UsersService {
 		double averageRating = reviewRepository.averageRatingByReviewee(user);
 		List<ReviewDto> reviewsRecentlyTop5 = reviewRepository.findTop5ByRevieweeOrderByCreatedAtDesc(user)
 			.stream()
-			.map(ReviewDto::of)
+			.map(review -> ReviewDto.of(review, cdnUrl + review.getWriter().getProfileImageUrl()))
 			.toList();
 		long totalReviewCount = reviewRepository.countByReviewee(user);
 
 		// 프로필 이미지가 내부 저장 이미지일 때, 처리
 		String profileImageUrl = user.getProfileImageUrl();
-		if (!profileImageUrl.startsWith("http")) {
-			profileImageUrl = awsS3Service.generatePreSignedImageUrl(profileImageUrl.trim());
+		if (!profileImageUrl.trim().startsWith("http")) {
+			profileImageUrl = cdnUrl + profileImageUrl;
 		}
 
 		return new UserPageDto(
@@ -91,14 +93,14 @@ public class UsersServiceImpl implements UsersService {
 	@Transactional
 	public void updateProfileImage(MultipartFile file) {
 		Users user = currentUserService.getCurrentUser();
-		user.updateProfileImageUrl(awsS3Service.updateUserProfileImage(user, file));
+		user.setProfileImageUrl(awsS3Service.updateUserProfileImage(user, file));
+		usersRepository.save(user);
 	}
 
 	@Override
-	@Transactional
 	public void updateNickname(UserNicknameDto dto) {
 		Users user = currentUserService.getCurrentUser();
-		user.updateNickname(dto.getNickname());
+		user.setNickname(dto.getNickname());
 		usersRepository.save(user);
 	}
 

--- a/src/main/resources/application-aws.yaml
+++ b/src/main/resources/application-aws.yaml
@@ -2,7 +2,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 5MB # default 1MB
-      max-request-size: 10MB
+      max-request-size: 30MB
 
   data:
     redis:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -30,5 +30,8 @@ cloud:
       access-key: ${AWS_S3_ACCESS_KEY}
       secret-key: ${AWS_S3_SECRET_KEY}
 
+    cloudfront:
+      url: ${CLOUDFRONT_URL}
+
 firebase:
   config-path: firebase-admin.json

--- a/src/main/resources/application-prd.yaml
+++ b/src/main/resources/application-prd.yaml
@@ -23,5 +23,8 @@ cloud:
     credentials:
       instance-profile: true  # IAM Role 사용
 
+    cloudfront:
+      url: ${CLOUDFRONT_URL}
+
 firebase:
   config-env: ${FIREBASE_CONFIG}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -23,3 +23,6 @@ cloud:
       bucket: test-bucket
     stack:
       auto: false
+
+    cloudfront:
+      url: cloudfront

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -159,9 +159,6 @@ public class AuthServiceTest {
 		when(jwtProvider.getEmailFromToken(validAccessToken)).thenReturn(email);
 		when(usersRepository.findByEmail(email)).thenReturn(Optional.of(user));
 
-		when(awsS3Service.generatePreSignedImageUrl(user.getProfileImageUrl()))
-			.thenReturn(imageUrl);
-
 		// When
 		UserResponseDTO userResponseDTO = authService.getUserInfo("Bearer " + validAccessToken);
 

--- a/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.net.URL;
-import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -28,8 +26,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @ExtendWith(MockitoExtension.class)
 class AwsS3ServiceTest {
@@ -75,32 +71,10 @@ class AwsS3ServiceTest {
 		// Then
 		assertFalse(uploadedFiles.isEmpty());
 		assertEquals(1, uploadedFiles.size());
-		assertTrue(uploadedFiles.get(0).getFirst().contains("images/goods/1/"));
+		assertTrue(uploadedFiles.get(0).getFirst().contains("goods/1/"));
 		assertEquals("image/jpeg", uploadedFiles.get(0).getSecond());
 
 		verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
-	}
-
-	@Test
-	@DisplayName("이미지 pre-signed 경로 가져오기 성공")
-	void generatePreSignedImageUrl_Success() throws IOException {
-		// Given
-		GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-			.signatureDuration(Duration.ofMinutes(10))
-			.getObjectRequest(req -> req.bucket(bucketName).key(s3Key))
-			.build();
-
-		PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
-		when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presignedRequest);
-		URL preSigneUrlObject = new URL(preSignedUrl);
-		doReturn(preSigneUrlObject).when(presignedRequest).url();
-
-		// When
-		String resultUrl = awsS3Service.generatePreSignedImageUrl(s3Key);
-
-		// Then
-		assertEquals(preSignedUrl, resultUrl);
-		verify(s3Presigner, times(1)).presignGetObject(any(GetObjectPresignRequest.class));
 	}
 
 	@Test
@@ -136,7 +110,7 @@ class AwsS3ServiceTest {
 		String uploadedS3Key = awsS3Service.updateUserProfileImage(mockUser, mockFile);
 
 		// Then
-		assertTrue(uploadedS3Key.contains("images/users/1/"));
+		assertTrue(uploadedS3Key.contains("users/1/"));
 		verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 	}
 

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,9 +63,6 @@ class ChatServiceTest {
 	private CurrentUserService currentUserService;
 
 	@Mock
-	private AwsS3Service awsS3Service;
-
-	@Mock
 	private TradesRepository tradesRepository;
 
 	@Mock
@@ -72,6 +70,13 @@ class ChatServiceTest {
 
 	@InjectMocks
 	private ChatServiceImpl chatService;
+
+	private final String testCdnUrl = "http://example.com/";
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(chatService, "cdnUrl", testCdnUrl);
+	}
 
 	@Test
 	@DisplayName("물건 기반 채팅방 생성 테스트")
@@ -151,7 +156,7 @@ class ChatServiceTest {
 
 		Users owner = Users.builder()
 			.usersId(2L)
-			.profileImageUrl("http://example.com/profile.jpg")
+			.profileImageUrl("profile.jpg")
 			.nickname("ownerNick")
 			.build();
 		Goods goods = Goods.builder()
@@ -184,7 +189,7 @@ class ChatServiceTest {
 		assertEquals(1, result.size());
 		ChatRoomResponseDto dto = result.get(0);
 		assertEquals(2L, dto.getUsersId()); // 상대방의 id
-		assertEquals("http://example.com/profile.jpg", dto.getProfileImageUrl());
+		assertEquals(testCdnUrl + "profile.jpg", dto.getProfileImageUrl());
 		assertEquals("안녕하세요", dto.getRecentChat());
 	}
 
@@ -319,9 +324,7 @@ class ChatServiceTest {
 		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods))
 			.thenReturn(Optional.of(goodsImages));
 
-		String expectedImageUrl = "http://example.com/test-image.jpg";
-		when(awsS3Service.generatePreSignedImageUrl("test-key"))
-			.thenReturn(expectedImageUrl);
+		String expectedImageUrl = testCdnUrl + goodsImages.getS3Key();
 
 		// when
 		ChatRoomGoodsDto result = chatService.getChatRoomGoods(chatroomId);

--- a/src/test/java/com/example/swapit/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ReviewServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.swapit.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.Reviews;
+import com.example.swapit.domain.TradeStatus;
+import com.example.swapit.domain.Trades;
+import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ReviewListDto;
 import com.example.swapit.domain.dto.ReviewRequestDto;
 import com.example.swapit.repository.ReviewRepository;
@@ -49,7 +53,7 @@ class ReviewServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		writer = Users.builder().usersId(1L).build();
+		writer = Users.builder().usersId(1L).profileImageUrl("image").build();
 		owner = Users.builder().usersId(2L).build();
 
 		requestedGoods = Goods.builder().user(writer).build();

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,15 +65,19 @@ public class TradesServiceTest {
 	private CurrentUserServiceImpl currentUserService;
 
 	@Mock
-	private AwsS3Service awsS3Service;
-
-	@Mock
 	private ChatNotificationService chatNotificationService;
 
 	@Mock
 	private NotificationEventPublisher notificationEventPublisher;
 
 	private TradesRequestDto dto;
+
+	private final String testCdnUrl = "http://example.com/";
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(tradesService, "cdnUrl", testCdnUrl);
+	}
 
 	@Test
 	@DisplayName("거래 요청 성공")
@@ -532,7 +537,6 @@ public class TradesServiceTest {
 
 		GoodsImages goodsImages = GoodsImages.builder().s3Key("s3Key123").build();
 		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(goods)).thenReturn(Optional.of(goodsImages));
-		when(awsS3Service.generatePreSignedImageUrl("s3Key123")).thenReturn("http://image.url/123");
 
 		// when
 		List<MyGoodsDto> result = tradesService.getMyGoods();
@@ -543,7 +547,7 @@ public class TradesServiceTest {
 		assertEquals("Item", dto.getTitle());
 		assertEquals(10000L, dto.getPrice());
 		assertEquals("MISC", dto.getCategory());
-		assertEquals("http://image.url/123", dto.getPhotoUrl());
+		assertEquals(testCdnUrl + goodsImages.getS3Key(), dto.getPhotoUrl());
 		assertEquals(5L, dto.getRequestCount());
 	}
 
@@ -569,10 +573,9 @@ public class TradesServiceTest {
 		when(tradesRepository.findGoodsRequests(goodsId)).thenReturn(goodsList);
 
 		GoodsImages goodsImages = GoodsImages.builder()
-			.s3Key("s3Key200")
+			.s3Key("s3Key")
 			.build();
 		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(myGoods)).thenReturn(Optional.of(goodsImages));
-		when(awsS3Service.generatePreSignedImageUrl("s3Key200")).thenReturn("http://image.url/200");
 
 		// when
 		TradeMyGoodsRequestDto result = tradesService.getGoodsRequests(goodsId);
@@ -587,7 +590,7 @@ public class TradesServiceTest {
 		assertEquals("Item", dto.getTitle());
 		assertEquals(10000L, dto.getPrice());
 		assertEquals("MISC", dto.getCategory());
-		assertEquals("http://image.url/200", dto.getPhotoUrl());
+		assertEquals(testCdnUrl + goodsImages.getS3Key(), dto.getPhotoUrl());
 	}
 
 	@Test
@@ -613,18 +616,13 @@ public class TradesServiceTest {
 		Users dummyUser = Users.builder().usersId(1L).build();
 		when(currentUserService.getCurrentUser()).thenReturn(dummyUser);
 
-		GoodsImages requestedGoodsImage = GoodsImages.builder().s3Key("s3Key300").build();
+		GoodsImages requestedGoodsImage = GoodsImages.builder().s3Key("s3Key3").build();
 		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(requestedGoods))
 			.thenReturn(Optional.of(requestedGoodsImage));
-		when(awsS3Service.generatePreSignedImageUrl("s3Key300"))
-			.thenReturn("http://image.url/300");
 
-		GoodsImages myGoodsImage = GoodsImages.builder().s3Key("s3Key400").build();
+		GoodsImages myGoodsImage = GoodsImages.builder().s3Key("s3Key4").build();
 		when(goodsImagesRepository.findFirstByGoodOrderByIdAsc(myGoods))
 			.thenReturn(Optional.of(myGoodsImage));
-		when(awsS3Service.generatePreSignedImageUrl("s3Key400"))
-			.thenReturn("http://image.url/400");
-
 		// when
 		List<MyRequestDto> result = tradesService.getMyRequests();
 
@@ -633,7 +631,7 @@ public class TradesServiceTest {
 		MyRequestDto dto = result.get(0);
 		assertEquals("Requested Item", dto.getTitle());
 		assertEquals(3000L, dto.getPrice());
-		assertEquals("http://image.url/400", dto.getMyGoodsPhotoUrl());
-		assertEquals("http://image.url/300", dto.getTargetGoodsPhotoUrl());
+		assertEquals(testCdnUrl + myGoodsImage.getS3Key(), dto.getMyGoodsPhotoUrl());
+		assertEquals(testCdnUrl + requestedGoodsImage.getS3Key(), dto.getTargetGoodsPhotoUrl());
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#39

## 📝 작업 내용
- 이미지 업로드 최대 사이즈 30mb로 변경
- 이전의 generateUrl해서 사용한 것에서 cloudfront를 붙여 s3 버킷이름을 api에서 가림.
- 기존의 로직에서 imageUrl을 가져다 쓰는 부분 모두 변경
- 테스트 코드도 따라서 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
