### PR TITLE
[HOTFIX] 이미지 조회 에러 해결

### DIFF
--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.swapit.service;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,9 +34,10 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucketName;
 
-	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png"); // 이미지 가능 확장자
 	private final String baseUrl = "images/";
 	private final S3Client s3Client;
+	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png"); // 이미지 가능 확장자
+	private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpg", "image/jpeg", "image/png");
 
 	/**
 	 * 이미지 업로드
@@ -46,7 +49,8 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 				if (!isValidImageFile(file.getOriginalFilename())) {
 					throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
 				}
-				String s3Key = uploadFileToS3(file, "goods/" + good.getId());
+				String contentType = detectMimeType(file);
+				String s3Key = uploadFileToS3(file, "goods/" + good.getId(), contentType);
 				return Pair.of(s3Key, file.getContentType());
 			}).toList();
 	}
@@ -61,13 +65,15 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	public String updateUserProfileImage(Users user, MultipartFile file) {
 		isValidImageFile(file.getOriginalFilename());
 		deleteFileFromS3(user.getProfileImageUrl()); // 기존 이미지 삭제
-		return uploadFileToS3(file, "users/" + user.getUsersId());
+
+		String contentType = detectMimeType(file);
+		return uploadFileToS3(file, "users/" + user.getUsersId(), contentType);
 	}
 
 	/**
 	 *  S3에 파일 업로드 후 S3 key 반환
 	 */
-	private String uploadFileToS3(MultipartFile file, String path) {
+	private String uploadFileToS3(MultipartFile file, String path, String contentType) {
 		String uniqueFileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
 		String s3Key = path + "/" + uniqueFileName;
 
@@ -75,7 +81,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 			PutObjectRequest putRequest = PutObjectRequest.builder()
 				.bucket(bucketName)
 				.key(baseUrl + s3Key)
-				.contentType(file.getContentType())
+				.contentType(contentType)
 				.build();
 
 			s3Client.putObject(putRequest, RequestBody.fromBytes(file.getBytes()));
@@ -115,5 +121,37 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 			originalFileName.lastIndexOf(".") + 1).toLowerCase();
 
 		return ALLOWED_EXTENSIONS.contains(fileExtension);
+	}
+
+	/**
+	 * MultipartFile에서 정확한 MIME 타입 감지하는 함수
+	 */
+	private String detectMimeType(MultipartFile file) {
+		try {
+			// Java에서 파일 MIME 타입을 직접 감지
+			Path tempFile = Files.createTempFile("upload", file.getOriginalFilename());
+			Files.copy(file.getInputStream(), tempFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+			String mimeType = Files.probeContentType(tempFile);
+			Files.delete(tempFile); // 임시 파일 삭제
+
+			if (mimeType == null) {
+				throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+			}
+
+			if (ALLOWED_MIME_TYPES.contains(mimeType)) {
+				return mimeType; // 허용된 이미지 포맷이면 그대로 반환
+			}
+
+			// 이미지이지만 허용되지 않은 경우 예외 발생
+			if (mimeType.startsWith("image/")) {
+				throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+			}
+			// 이미지가 아니면 예외 발생
+			throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+
+		} catch (IOException e) {
+			log.error("MIME 타입 감지 실패: {}", e.getMessage());
+			throw new CustomException(ErrorCode.IMAGE_READ_FAILED);
+		}
 	}
 }

--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -1,9 +1,12 @@
 package com.example.swapit.service;
 
+import static com.google.common.io.Files.*;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -37,7 +40,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	private final String baseUrl = "images/";
 	private final S3Client s3Client;
 	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png"); // 이미지 가능 확장자
-	private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpg", "image/jpeg", "image/png");
+	private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpeg", "image/png");
 
 	/**
 	 * 이미지 업로드
@@ -51,7 +54,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 				}
 				String contentType = detectMimeType(file);
 				String s3Key = uploadFileToS3(file, "goods/" + good.getId(), contentType);
-				return Pair.of(s3Key, file.getContentType());
+				return Pair.of(s3Key, contentType);
 			}).toList();
 	}
 
@@ -133,9 +136,17 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 			Files.copy(file.getInputStream(), tempFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 			String mimeType = Files.probeContentType(tempFile);
 			Files.delete(tempFile); // 임시 파일 삭제
+			log.debug("[이미지 업로드 감지] 이미지 확장자 확인 : {}", mimeType);
 
-			if (mimeType == null) {
-				throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+			if (mimeType == null || mimeType.equals("application/octet-stream")) {
+				// MIME 타입을 감지하지 못하면 확장자로 결정
+				String fileExtension = getFileExtension(Objects.requireNonNull(file.getOriginalFilename()));
+
+				return switch (fileExtension) {
+					case "jpg", "jpeg" -> "image/jpeg";
+					case "png" -> "image/png";
+					default -> throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+				};
 			}
 
 			if (ALLOWED_MIME_TYPES.contains(mimeType)) {

--- a/src/main/resources/application-prd.yaml
+++ b/src/main/resources/application-prd.yaml
@@ -28,3 +28,7 @@ cloud:
 
 firebase:
   config-env: ${FIREBASE_CONFIG}
+
+logging:
+  level:
+    com.example.swapit: debug

--- a/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
@@ -3,6 +3,7 @@ package com.example.swapit.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -50,7 +51,7 @@ class AwsS3ServiceTest {
 	private static final String preSignedUrl = "https://s3.test-bucket.com/sample.jpg";
 	private static final String INVALID_FILE_NAME = "test-document.pdf";
 	private static final Long goodsId = 1L;
-	private static final String VALID_FILE_NAME = "test-image.jpg";
+	private static final String VALID_FILE_NAME = "test-image.jpeg";
 	private static final String CONTENT_TYPE = "image/jpeg";
 
 	@Test
@@ -60,8 +61,8 @@ class AwsS3ServiceTest {
 		Goods mockGoods = mock(Goods.class);
 		when(mockGoods.getId()).thenReturn(goodsId);
 		when(mockFile.getOriginalFilename()).thenReturn(VALID_FILE_NAME);
-		when(mockFile.getContentType()).thenReturn(CONTENT_TYPE);
 		when(mockFile.getBytes()).thenReturn(new byte[10]);
+		when(mockFile.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[10]));
 
 		when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
 
@@ -72,7 +73,7 @@ class AwsS3ServiceTest {
 		assertFalse(uploadedFiles.isEmpty());
 		assertEquals(1, uploadedFiles.size());
 		assertTrue(uploadedFiles.get(0).getFirst().contains("goods/1/"));
-		assertEquals("image/jpeg", uploadedFiles.get(0).getSecond());
+		assertEquals(CONTENT_TYPE, uploadedFiles.get(0).getSecond());
 
 		verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 	}
@@ -99,10 +100,9 @@ class AwsS3ServiceTest {
 		// given
 		Users mockUser = mock(Users.class);
 		when(mockUser.getUsersId()).thenReturn(1L);
-		when(mockUser.getProfileImageUrl()).thenReturn(null);
 		when(mockFile.getOriginalFilename()).thenReturn(VALID_FILE_NAME);
-		when(mockFile.getContentType()).thenReturn(CONTENT_TYPE);
 		when(mockFile.getBytes()).thenReturn(new byte[10]);
+		when(mockFile.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[10]));
 
 		when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
 
@@ -132,8 +132,8 @@ class AwsS3ServiceTest {
 		Goods mockGoods = mock(Goods.class);
 		when(mockGoods.getId()).thenReturn(1L);
 		when(mockFile.getOriginalFilename()).thenReturn(VALID_FILE_NAME);
-		when(mockFile.getContentType()).thenReturn(CONTENT_TYPE);
 		when(mockFile.getBytes()).thenReturn(new byte[10]);
+		when(mockFile.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[10]));
 
 		doThrow(new RuntimeException("S3 upload failed"))
 			.when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#95 

## 📝 작업 내용
- 기존의 MultipartFile에서 바로 getContentType으로 content Type을 s3에 주입하는 방식에서, 직접 Multifile을 확인해 mimeType을 가져와 s3에 contentType을 지정하는 방식으로 변경
- application-prd.yaml을 안드로이드 개발 완료되는 동안 로그 debug모드로 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
안드로이드 분들 개발할 때 운영에서의 현재 상황을 빠르게 파악하기 위해 
안드로이드분들 개발 완료할 때까지만 debug 모드로 변경하는 건 어떨까요?
