### PR TITLE
[fix] 채팅방 물건 api 응답에 채팅 상대 닉네임 추가

### DIFF
--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -13,7 +13,7 @@ import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomListResponseDto;
 import com.example.swapit.service.ChatService;
 
@@ -57,7 +57,7 @@ public class ChatController {
 	}
 
 	@GetMapping("/api/user/chatroom/{chatroomId}/goods")
-	public ApiResponse<ChatRoomGoodsDto> getChatRoomGoods(@PathVariable Long chatroomId) {
+	public ApiResponse<ChatRoomInfoDto> getChatRoomGoods(@PathVariable Long chatroomId) {
 		return ApiResponse.success(chatService.getChatRoomGoods(chatroomId));
 	}
 }

--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
@@ -5,10 +5,11 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ChatRoomGoodsDto {
+public class ChatRoomInfoDto {
 	private Long goodsId;
 	private String title;
 	private String category;
 	private long price;
 	private String imageUrl;
+	private String nickname;
 }

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
@@ -22,5 +22,5 @@ public interface ChatService {
 
 	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, Long userId);
 
-	ChatRoomGoodsDto getChatRoomGoods(Long chatroomId);
+	ChatRoomInfoDto getChatRoomGoods(Long chatroomId);
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -22,7 +22,7 @@ import com.example.swapit.domain.dto.chat.ChatDto;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
@@ -99,37 +99,14 @@ public class ChatServiceImpl implements ChatService {
 		return chatRooms.stream()
 			.filter(chatRoom -> chatRepository.countByChatRoomsId(chatRoom.getId()) > 0)
 			.map(chatRoom -> {
-				Trades trade = chatRoom.getTrade();
-				Long counterpartId;
-
-				if (trade == null) {
-					// 거래가 없는 채팅방
-					// "채팅방의 물건 소유자" vs "inviter" 중, 내가 아닌 쪽이 상대방
-					if (chatRoom.getGoods().getUser().getUsersId().equals(loggedInUserId)) {
-						counterpartId = chatRoom.getInviter().getUsersId();
-					} else {
-						counterpartId = chatRoom.getGoods().getUser().getUsersId();
-					}
-				} else {
-					// 거래가 있는 채팅방
-					// targetGoods의 user가 나면, requestedGoods.user가 상대방
-					// 반대면, targetGoods.user가 상대방
-					if (trade.getTargetGoods().getUser().getUsersId().equals(loggedInUserId)) {
-						counterpartId = trade.getRequestedGoods().getUser().getUsersId();
-					} else {
-						counterpartId = trade.getTargetGoods().getUser().getUsersId();
-					}
-				}
-
-				Users counterpart = usersRepository.findById(counterpartId)
-					.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+				Users counterpart = getCounterpart(chatRoom);
 				String userProfileImageUrl = counterpart.getProfileImageUrl().trim().startsWith("http")
 					? counterpart.getProfileImageUrl() : cdnUrl + counterpart.getProfileImageUrl();
 
 				Chats chats = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId());
 
 				return ChatRoomResponseDto.builder()
-					.usersId(counterpartId)
+					.usersId(counterpart.getUsersId())
 					.profileImageUrl(userProfileImageUrl)
 					.nickname(counterpart.getNickname())
 					.recentChat(chats.getContent())
@@ -206,7 +183,7 @@ public class ChatServiceImpl implements ChatService {
 	}
 
 	@Override
-	public ChatRoomGoodsDto getChatRoomGoods(Long chatroomId) {
+	public ChatRoomInfoDto getChatRoomGoods(Long chatroomId) {
 		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
 			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
 		Goods goods = chatRooms.getGoods();
@@ -214,13 +191,42 @@ public class ChatServiceImpl implements ChatService {
 			.map(GoodsImages::getS3Key)
 			.map(s3Key -> cdnUrl + s3Key)
 			.orElse(null);
+		Users counterpart = getCounterpart(chatRooms);
 
-		return new ChatRoomGoodsDto(
+		return new ChatRoomInfoDto(
 			goods.getId(),
 			goods.getTitle(),
 			goods.getCategory().getName(),
 			goods.getPrice(),
-			firstImageUrl
+			firstImageUrl,
+			counterpart.getNickname()
 		);
+	}
+
+	public Users getCounterpart(ChatRooms chatRoom) {
+		Long loggedInUserId = currentUserService.getCurrentUser().getUsersId();
+		Users counterpart;
+		Trades trade = chatRoom.getTrade();
+
+		if (trade == null) {
+			// 거래가 없는 채팅방
+			// "채팅방의 물건 소유자" vs "inviter" 중, 내가 아닌 쪽이 상대방
+			if (chatRoom.getGoods().getUser().getUsersId().equals(loggedInUserId)) {
+				counterpart = chatRoom.getInviter();
+			} else {
+				counterpart = chatRoom.getGoods().getUser();
+			}
+		} else {
+			// 거래가 있는 채팅방
+			// targetGoods의 user가 나면, requestedGoods.user가 상대방
+			// 반대면, targetGoods.user가 상대방
+			if (trade.getTargetGoods().getUser().getUsersId().equals(loggedInUserId)) {
+				counterpart = trade.getRequestedGoods().getUser();
+			} else {
+				counterpart = trade.getTargetGoods().getUser();
+			}
+		}
+
+		return counterpart;
 	}
 }

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -1,8 +1,8 @@
 package com.example.swapit.controller;
 
 import static org.hamcrest.Matchers.*;
-import static org.mockito.BDDMockito.*;
 import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -24,7 +24,7 @@ import com.example.swapit.domain.dto.chat.ChatDto;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.service.ChatService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -167,8 +167,8 @@ class ChatControllerTest {
 	@DisplayName("채팅방 물건 조회 성공")
 	void getChatRoomGoods() throws Exception {
 		// given
-		ChatRoomGoodsDto dto = new ChatRoomGoodsDto(
-			1L, "아이폰 15", "ELECTRONICS", 2500L, null);
+		ChatRoomInfoDto dto = new ChatRoomInfoDto(
+			1L, "아이폰 15", "ELECTRONICS", 2500L, null, "닉네임");
 
 		given(chatService.getChatRoomGoods(any())).willReturn(dto);
 

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -26,7 +26,7 @@ import com.example.swapit.domain.dto.chat.ChatDto;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.service.ChatServiceImpl;
 
@@ -231,8 +231,8 @@ public class ChatControllerDocsTest extends RestDocsTest {
 	void getChatRoomGoods() throws Exception {
 		// Given
 		Long chatroomId = 1L;
-		ChatRoomGoodsDto dto = new ChatRoomGoodsDto(
-			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg");
+		ChatRoomInfoDto dto = new ChatRoomInfoDto(
+			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", "닉네임");
 
 		given(chatService.getChatRoomGoods(any())).willReturn(dto);
 
@@ -256,7 +256,8 @@ public class ChatControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.title").type(JsonFieldType.STRING).description("물건 제목"),
 						fieldWithPath("results.category").type(JsonFieldType.STRING).description("물건 카테고리"),
 						fieldWithPath("results.price").type(JsonFieldType.NUMBER).description("물건 예상 가격"),
-						fieldWithPath("results.imageUrl").type(JsonFieldType.STRING).description("물건 이미지 URL")
+						fieldWithPath("results.imageUrl").type(JsonFieldType.STRING).description("물건 이미지 URL"),
+						fieldWithPath("results.nickname").type(JsonFieldType.STRING).description("채팅방 상대 닉네임")
 					)
 					.responseSchema(Schema.schema("ChatRoomGoodsDto"))
 					.build()

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -151,12 +151,16 @@ class ChatServiceTest {
 	@DisplayName("채팅방 목록 조회 성공")
 	void getChatRoomListTest() {
 		// Given
-		Users currentUser = Users.builder().usersId(1L).email("current@example.com").build();
+		Users currentUser = Users.builder()
+			.usersId(1L)
+			.email("current@example.com")
+			.profileImageUrl(testCdnUrl + "profileImage.jpg")
+			.build();
 		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
 
 		Users owner = Users.builder()
 			.usersId(2L)
-			.profileImageUrl("profile.jpg")
+			.profileImageUrl(testCdnUrl + "profile.jpg")
 			.nickname("ownerNick")
 			.build();
 		Goods goods = Goods.builder()
@@ -167,6 +171,7 @@ class ChatServiceTest {
 			.id(1L)
 			.inviter(currentUser)
 			.goods(goods)
+			.trade(null)
 			.build();
 
 		when(chatRoomsRepository.findMyChatRooms(1L)).thenReturn(List.of(chatRoom));
@@ -178,8 +183,6 @@ class ChatServiceTest {
 			.build();
 
 		when(chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(1L)).thenReturn(latestChat);
-
-		when(usersRepository.findById(2L)).thenReturn(Optional.of(owner));
 
 		// When
 		List<ChatRoomResponseDto> result = chatService.getChatRoomList();
@@ -304,11 +307,22 @@ class ChatServiceTest {
 		Categories category = Categories.builder()
 			.name("ELECTRONIC").build();
 
+		Users currentUser = Users.builder()
+			.usersId(2L)
+			.nickname("nickname")
+			.build();
+
+		Users counterpart = Users.builder()
+			.usersId(1L)
+			.nickname("닉네임")
+			.build();
+
 		Goods goods = Goods.builder()
 			.title("Test Good")
 			.price(1000L)
 			.category(category)
 			.placeName("TestPlace")
+			.user(currentUser)
 			.build();
 
 		ChatRooms chatRooms = ChatRooms.builder()
@@ -325,6 +339,9 @@ class ChatServiceTest {
 			.thenReturn(Optional.of(goodsImages));
 
 		String expectedImageUrl = testCdnUrl + goodsImages.getS3Key();
+
+		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
+		when(chatService.getCounterpart(chatRooms)).thenReturn(counterpart);
 
 		// when
 		ChatRoomInfoDto result = chatService.getChatRoomGoods(chatroomId);

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -29,7 +29,7 @@ import com.example.swapit.domain.dto.chat.ChatDto;
 import com.example.swapit.domain.dto.chat.ChatListDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
-import com.example.swapit.domain.dto.chat.ChatRoomGoodsDto;
+import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
@@ -327,7 +327,7 @@ class ChatServiceTest {
 		String expectedImageUrl = testCdnUrl + goodsImages.getS3Key();
 
 		// when
-		ChatRoomGoodsDto result = chatService.getChatRoomGoods(chatroomId);
+		ChatRoomInfoDto result = chatService.getChatRoomGoods(chatroomId);
 
 		// then
 		assertNotNull(result);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #98 

## 📝 작업 내용

> 채팅방 물건 api 응답에 채팅 상대 닉네임 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 없습니다!
