### PR TITLE
[Feat] 채팅 안읽은 개수 구현

### DIFF
--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -56,8 +56,8 @@ public class ChatController {
 		return ApiResponse.success(chatService.getChatList(chatroomId, cursorId, createdAt));
 	}
 
-	@GetMapping("/api/user/chatroom/{chatroomId}/goods")
+	@GetMapping("/api/user/chatroom/{chatroomId}/info")
 	public ApiResponse<ChatRoomInfoDto> getChatRoomGoods(@PathVariable Long chatroomId) {
-		return ApiResponse.success(chatService.getChatRoomGoods(chatroomId));
+		return ApiResponse.success(chatService.getChatRoomInfo(chatroomId));
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -13,6 +13,7 @@ import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.config.websocket.StompPrincipal;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
+import com.example.swapit.domain.dto.chat.ReadReceiptRequestDto;
 import com.example.swapit.service.ChatService;
 
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,17 @@ public class ChatWebSocketController {
 		} else {
 			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
 		}
+	}
+
+	@MessageMapping("/chat/read/{chatroomId}")
+	public void updateReadReceipt(@DestinationVariable Long chatroomId, ReadReceiptRequestDto receipt,
+		Principal principal) {
+		if (principal == null) {
+			log.error("[ERROR] WebSocket 읽음 이벤트 처리 실패: Principal이 null입니다.");
+			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+		}
+
+		Long userId = Long.parseLong(principal.getName());
+		chatService.updateReadReceipt(chatroomId, userId, receipt.getLastReadChatId());
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -49,7 +49,7 @@ public class ChatWebSocketController {
 		Principal principal) {
 		if (principal == null) {
 			log.error("[ERROR] WebSocket 읽음 이벤트 처리 실패: Principal이 null입니다.");
-			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+			return;
 		}
 
 		Long userId = Long.parseLong(principal.getName());

--- a/src/main/java/com/example/swapit/domain/ChatRooms.java
+++ b/src/main/java/com/example/swapit/domain/ChatRooms.java
@@ -44,10 +44,20 @@ public class ChatRooms {
 	@JoinColumn(name = "inviter_id", nullable = false)
 	private Users inviter;
 
+	@Setter
+	@Column(name = "inviter_last_read_id", nullable = false)
+	private Long inviterLastReadId;
+
+	@Setter
+	@Column(name = "not_inviter_last_read_id", nullable = false)
+	private Long notInviterLastReadId;
+
 	public ChatRooms(Goods goods, Users inviter, Trades trade) {
 		this.goods = goods;
 		this.inviter = inviter;
 		this.trade = trade;
+		this.inviterLastReadId = 0L;
+		this.notInviterLastReadId = 0L;
 	}
 
 	public void updateTrade(Trades trade) {

--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
@@ -11,5 +11,6 @@ public class ChatRoomInfoDto {
 	private String category;
 	private long price;
 	private String imageUrl;
+	private Long usersId;
 	private String nickname;
 }

--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomResponseDto.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Builder
 @Getter
 public class ChatRoomResponseDto {
-	private Long usersId;
 	private String profileImageUrl;
 	private String nickname;
 	private String recentChat;

--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomResponseDto.java
@@ -13,4 +13,5 @@ public class ChatRoomResponseDto {
 	private String nickname;
 	private String recentChat;
 	private LocalDateTime recentChatTime;
+	private long unReadChatCount;
 }

--- a/src/main/java/com/example/swapit/domain/dto/chat/ReadReceiptRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ReadReceiptRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.swapit.domain.dto.chat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadReceiptRequestDto {
+	private Long lastReadChatId;
+}

--- a/src/main/java/com/example/swapit/repository/ChatsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatsRepository.java
@@ -14,12 +14,18 @@ public interface ChatsRepository extends JpaRepository<Chats, Long> {
 	Chats findTopByChatRoomsIdOrderByCreatedAtDesc(Long chatRoomsId);
 
 	@Query("SELECT c FROM Chats c "
-		+ "WHERE c.chatRooms.id = :chatRoomsId "
-		+ "AND (:createdAt IS NULL OR c.createdAt < :createdAt OR (c.createdAt = :createdAt AND c.id < :cursorId)) "
-		+ "ORDER BY c.createdAt DESC")
+		   + "WHERE c.chatRooms.id = :chatRoomsId "
+		   + "AND (:createdAt IS NULL OR c.createdAt < :createdAt OR (c.createdAt = :createdAt AND c.id < :cursorId)) "
+		   + "ORDER BY c.createdAt DESC")
 	List<Chats> findAllByChatRoomsId(@Param("chatRoomsId") Long chatRoomsId,
 		@Param("cursorId") Long cursorId,
 		@Param("createdAt") LocalDateTime createdAt);
 
 	long countByChatRoomsId(Long chatroomId);
+
+	@Query("SELECT COUNT(*) "
+		   + "FROM Chats c "
+		   + "WHERE c.chatRooms.id = :chatRoomsId "
+		   + "AND c.id > :lastReadId")
+	long findUnreadChatCount(long chatRoomsId, long lastReadId);
 }

--- a/src/main/java/com/example/swapit/service/ChatSendService.java
+++ b/src/main/java/com/example/swapit/service/ChatSendService.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ChatNotificationService {
+public class ChatSendService {
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatService chatService;
 	private final CurrentUserService currentUserService;

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -22,7 +22,7 @@ public interface ChatService {
 
 	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, Long userId);
 
-	ChatRoomInfoDto getChatRoomGoods(Long chatroomId);
+	ChatRoomInfoDto getChatRoomInfo(Long chatroomId);
 
 	void updateReadReceipt(Long chatroomId, Long userId, Long lastReadChatId);
 }

--- a/src/main/java/com/example/swapit/service/ChatService.java
+++ b/src/main/java/com/example/swapit/service/ChatService.java
@@ -23,4 +23,6 @@ public interface ChatService {
 	ChatStompResponseDto saveChat(Long chatroomId, ChatStompRequestDto chatDto, Long userId);
 
 	ChatRoomInfoDto getChatRoomGoods(Long chatroomId);
+
+	void updateReadReceipt(Long chatroomId, Long userId, Long lastReadChatId);
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -110,7 +110,6 @@ public class ChatServiceImpl implements ChatService {
 				long unreadChatCount = chatRepository.findUnreadChatCount(chatRoom.getId(), lastReadId);
 
 				return ChatRoomResponseDto.builder()
-					.usersId(counterpart.getUsersId())
 					.profileImageUrl(userProfileImageUrl)
 					.nickname(counterpart.getNickname())
 					.recentChat(chats.getContent())
@@ -188,7 +187,7 @@ public class ChatServiceImpl implements ChatService {
 	}
 
 	@Override
-	public ChatRoomInfoDto getChatRoomGoods(Long chatroomId) {
+	public ChatRoomInfoDto getChatRoomInfo(Long chatroomId) {
 		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
 			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
 		Goods goods = chatRooms.getGoods();
@@ -204,6 +203,7 @@ public class ChatServiceImpl implements ChatService {
 			goods.getCategory().getName(),
 			goods.getPrice(),
 			firstImageUrl,
+			counterpart.getUsersId(),
 			counterpart.getNickname()
 		);
 	}

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -105,12 +105,17 @@ public class ChatServiceImpl implements ChatService {
 
 				Chats chats = chatRepository.findTopByChatRoomsIdOrderByCreatedAtDesc(chatRoom.getId());
 
+				boolean isInviter = chatRoom.getInviter().getUsersId().equals(loggedInUserId);
+				long lastReadId = isInviter ? chatRoom.getInviterLastReadId() : chatRoom.getNotInviterLastReadId();
+				long unreadChatCount = chatRepository.findUnreadChatCount(chatRoom.getId(), lastReadId);
+
 				return ChatRoomResponseDto.builder()
 					.usersId(counterpart.getUsersId())
 					.profileImageUrl(userProfileImageUrl)
 					.nickname(counterpart.getNickname())
 					.recentChat(chats.getContent())
 					.recentChatTime(chats.getCreatedAt())
+					.unReadChatCount(unreadChatCount)
 					.build();
 			}).toList();
 	}
@@ -201,6 +206,22 @@ public class ChatServiceImpl implements ChatService {
 			firstImageUrl,
 			counterpart.getNickname()
 		);
+	}
+
+	@Override
+	@Transactional
+	public void updateReadReceipt(Long chatroomId, Long userId, Long lastReadChatId) {
+		ChatRooms chatRooms = chatRoomsRepository.findById(chatroomId)
+			.orElseThrow(() -> new CustomException(ErrorCode.CHATROOMS_NOT_FOUND));
+
+		boolean isInviter = chatRooms.getInviter().getUsersId().equals(userId);
+		if (isInviter) {
+			chatRooms.setInviterLastReadId(lastReadChatId);
+		} else {
+			chatRooms.setNotInviterLastReadId(lastReadChatId);
+		}
+
+		chatRoomsRepository.save(chatRooms);
 	}
 
 	public Users getCounterpart(ChatRooms chatRoom) {

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -49,7 +49,7 @@ public class TradesServiceImpl implements TradesService {
 	private final GoodsImagesRepository goodsImagesRepository;
 	private final ChatRoomsRepository chatRoomsRepository;
 	private final CurrentUserService currentUserService;
-	private final ChatNotificationService chatNotificationService;
+	private final ChatSendService chatSendService;
 	private final NotificationEventPublisher notificationEventPublisher;
 
 	public static final int MAX_REQUEST_COUNT = 10;
@@ -325,6 +325,6 @@ public class TradesServiceImpl implements TradesService {
 	protected void updateChatroomAndSendChat(ChatRooms chatRooms, Trades trade, ChatType chatType,
 		Goods goodsForMessage) {
 		chatRooms.updateTrade(trade);
-		chatNotificationService.sendTradeRequestChat(chatRooms.getId(), chatType, goodsForMessage);
+		chatSendService.sendTradeRequestChat(chatRooms.getId(), chatType, goodsForMessage);
 	}
 }

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -96,14 +96,12 @@ class ChatControllerTest {
 	void getChatRoomSuccess() throws Exception {
 		// given
 		ChatRoomResponseDto dto1 = ChatRoomResponseDto.builder()
-			.usersId(1L)
 			.profileImageUrl("http://example.com/image.jpg")
 			.nickname("testUser")
 			.recentChat("안녕하세요!")
 			.build();
 
 		ChatRoomResponseDto dto2 = ChatRoomResponseDto.builder()
-			.usersId(2L)
 			.profileImageUrl("http://example.com/image1.jpg")
 			.nickname("testUser2")
 			.recentChat("안녕하세요!!")
@@ -119,11 +117,9 @@ class ChatControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
 			.andExpect(jsonPath("$.results.chatRoomList", hasSize(2)))
-			.andExpect(jsonPath("$.results.chatRoomList[0].usersId").value(1))
 			.andExpect(jsonPath("$.results.chatRoomList[0].profileImageUrl").value("http://example.com/image.jpg"))
 			.andExpect(jsonPath("$.results.chatRoomList[0].nickname").value("testUser"))
 			.andExpect(jsonPath("$.results.chatRoomList[0].recentChat").value("안녕하세요!"))
-			.andExpect(jsonPath("$.results.chatRoomList[1].usersId").value(2))
 			.andExpect(jsonPath("$.results.chatRoomList[1].profileImageUrl").value("http://example.com/image1.jpg"))
 			.andExpect(jsonPath("$.results.chatRoomList[1].nickname").value("testUser2"))
 			.andExpect(jsonPath("$.results.chatRoomList[1].recentChat").value("안녕하세요!!"));
@@ -168,17 +164,17 @@ class ChatControllerTest {
 	void getChatRoomGoods() throws Exception {
 		// given
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
-			1L, "아이폰 15", "ELECTRONICS", 2500L, null, "닉네임");
+			1L, "아이폰 15", "ELECTRONICS", 2500L, null, 2L, "닉네임");
 
-		given(chatService.getChatRoomGoods(any())).willReturn(dto);
+		given(chatService.getChatRoomInfo(any())).willReturn(dto);
 
 		// when & then
-		mockMvc.perform(get("/api/user/chatroom/1/goods"))
+		mockMvc.perform(get("/api/user/chatroom/1/info"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
 			.andExpect(jsonPath("$.results.title").value("아이폰 15"));
 
-		verify(chatService, times(1)).getChatRoomGoods(any());
+		verify(chatService, times(1)).getChatRoomInfo(any());
 	}
 }

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -113,7 +113,6 @@ public class ChatControllerDocsTest extends RestDocsTest {
 		// Given
 		List<ChatRoomResponseDto> dtoList = new ArrayList<>();
 		ChatRoomResponseDto dto = ChatRoomResponseDto.builder()
-			.usersId(1L)
 			.profileImageUrl("http://example.com/image.jpg")
 			.nickname("testUser")
 			.recentChat("안녕하세요!")
@@ -139,15 +138,15 @@ public class ChatControllerDocsTest extends RestDocsTest {
 						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
 						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
 						fieldWithPath("results.chatRoomList").type(JsonFieldType.ARRAY).description("채팅방 목록"),
-						fieldWithPath("results.chatRoomList[].usersId").type(JsonFieldType.NUMBER)
-							.description("사용자 ID"),
 						fieldWithPath("results.chatRoomList[].profileImageUrl").type(JsonFieldType.STRING)
 							.description("프로필 이미지 URL"),
 						fieldWithPath("results.chatRoomList[].nickname").type(JsonFieldType.STRING).description("닉네임"),
 						fieldWithPath("results.chatRoomList[].recentChat").type(JsonFieldType.STRING)
 							.description("최근 메세지"),
 						fieldWithPath("results.chatRoomList[].recentChatTime").type(JsonFieldType.STRING)
-							.description("최근 채팅 시각")
+							.description("최근 채팅 시각"),
+						fieldWithPath("results.chatRoomList[].unReadChatCount").type(JsonFieldType.NUMBER)
+							.description("읽지 않은 채팅 개수")
 					)
 					.responseSchema(Schema.schema("ChatRoomListResponseDto"))
 					.build()
@@ -227,24 +226,24 @@ public class ChatControllerDocsTest extends RestDocsTest {
 	}
 
 	@Test
-	@DisplayName("채팅방 물건 조회 성공")
+	@DisplayName("채팅방 정보 조회 성공")
 	void getChatRoomGoods() throws Exception {
 		// Given
 		Long chatroomId = 1L;
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
-			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", "닉네임");
+			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", 2L, "닉네임");
 
-		given(chatService.getChatRoomGoods(any())).willReturn(dto);
+		given(chatService.getChatRoomInfo(any())).willReturn(dto);
 
 		// When & Then
-		mockMvc.perform(get("/api/user/chatroom/{chatroomId}/goods", chatroomId))
+		mockMvc.perform(get("/api/user/chatroom/{chatroomId}/info", chatroomId))
 			.andExpect(status().isOk())
-			.andDo(document("get-chat-room-goods",
+			.andDo(document("get-chat-room-info",
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				resource(ResourceSnippetParameters.builder()
 					.tag("Chat")
-					.description("채팅 방의 물건을 조회하는 API")
+					.description("채팅방의 정보를 조회하는 API")
 					.pathParameters(
 						parameterWithName("chatroomId").description("조회할 채팅방 ID")
 					)
@@ -257,9 +256,10 @@ public class ChatControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.category").type(JsonFieldType.STRING).description("물건 카테고리"),
 						fieldWithPath("results.price").type(JsonFieldType.NUMBER).description("물건 예상 가격"),
 						fieldWithPath("results.imageUrl").type(JsonFieldType.STRING).description("물건 이미지 URL"),
+						fieldWithPath("results.usersId").type(JsonFieldType.NUMBER).description("채팅방 상대 ID"),
 						fieldWithPath("results.nickname").type(JsonFieldType.STRING).description("채팅방 상대 닉네임")
 					)
-					.responseSchema(Schema.schema("ChatRoomGoodsDto"))
+					.responseSchema(Schema.schema("ChatRoomInfoDto"))
 					.build()
 				)
 			));

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -172,6 +172,8 @@ class ChatServiceTest {
 			.inviter(currentUser)
 			.goods(goods)
 			.trade(null)
+			.inviterLastReadId(3L)
+			.notInviterLastReadId(2L)
 			.build();
 
 		when(chatRoomsRepository.findMyChatRooms(1L)).thenReturn(List.of(chatRoom));
@@ -191,7 +193,6 @@ class ChatServiceTest {
 		assertNotNull(result);
 		assertEquals(1, result.size());
 		ChatRoomResponseDto dto = result.get(0);
-		assertEquals(2L, dto.getUsersId()); // 상대방의 id
 		assertEquals(testCdnUrl + "profile.jpg", dto.getProfileImageUrl());
 		assertEquals("안녕하세요", dto.getRecentChat());
 	}
@@ -344,7 +345,7 @@ class ChatServiceTest {
 		when(chatService.getCounterpart(chatRooms)).thenReturn(counterpart);
 
 		// when
-		ChatRoomInfoDto result = chatService.getChatRoomGoods(chatroomId);
+		ChatRoomInfoDto result = chatService.getChatRoomInfo(chatroomId);
 
 		// then
 		assertNotNull(result);
@@ -352,5 +353,56 @@ class ChatServiceTest {
 		assertEquals(goods.getPrice(), result.getPrice());
 		assertEquals(category.getName(), result.getCategory());
 		assertEquals(expectedImageUrl, result.getImageUrl());
+	}
+
+	@Test
+	@DisplayName("updateReadReceipt - inviter인 경우 inviterLastReadId 업데이트")
+	public void testUpdateReadReceipt_inviter() {
+		// given
+		Long chatroomId = 1L;
+		Long userId = 10L;
+		Long lastReadChatId = 100L;
+
+		Users inviter = Users.builder()
+			.usersId(userId)
+			.build();
+		ChatRooms chatRoom = ChatRooms.builder()
+			.inviter(inviter)
+			.build();
+
+		when(chatRoomsRepository.findById(chatroomId)).thenReturn(Optional.of(chatRoom));
+
+		// when
+		chatService.updateReadReceipt(chatroomId, userId, lastReadChatId);
+
+		// then
+		assertEquals(lastReadChatId, chatRoom.getInviterLastReadId());
+		verify(chatRoomsRepository, times(1)).save(chatRoom);
+	}
+
+	@Test
+	@DisplayName("updateReadReceipt - 초대자가 아닌 경우 notInviterLastReadId 업데이트")
+	public void testUpdateReadReceipt_nonInviter() {
+		// given
+		Long chatroomId = 1L;
+		Long inviterId = 10L;
+		Long userId = 20L;
+		Long lastReadChatId = 200L;
+
+		Users inviter = Users.builder()
+			.usersId(inviterId)
+			.build();
+		ChatRooms chatRoom = ChatRooms.builder()
+			.inviter(inviter)
+			.build();
+
+		when(chatRoomsRepository.findById(chatroomId)).thenReturn(Optional.of(chatRoom));
+
+		// when
+		chatService.updateReadReceipt(chatroomId, userId, lastReadChatId);
+
+		// then
+		assertEquals(lastReadChatId, chatRoom.getNotInviterLastReadId());
+		verify(chatRoomsRepository, times(1)).save(chatRoom);
 	}
 }

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -65,7 +65,7 @@ public class TradesServiceTest {
 	private CurrentUserServiceImpl currentUserService;
 
 	@Mock
-	private ChatNotificationService chatNotificationService;
+	private ChatSendService chatSendService;
 
 	@Mock
 	private NotificationEventPublisher notificationEventPublisher;
@@ -109,7 +109,7 @@ public class TradesServiceTest {
 
 		doNothing().when(notificationEventPublisher)
 			.publishNotification(eq(target.getUsersId()), eq(NotificationType.REQUESTED), eq(targetGoods.getId()));
-		doNothing().when(chatNotificationService)
+		doNothing().when(chatSendService)
 			.sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REQUEST), eq(requestedGoods));
 
 		// When
@@ -123,7 +123,7 @@ public class TradesServiceTest {
 		verify(notificationEventPublisher).publishNotification(eq(target.getUsersId()), eq(NotificationType.REQUESTED),
 			eq(targetGoods.getId()));
 		verify(chatRoomsRepository).findByGoodsAndInviter(targetGoods, requester);
-		verify(chatNotificationService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REQUEST),
+		verify(chatSendService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REQUEST),
 			eq(requestedGoods));
 
 		assertThat(returnedTradeId).isEqualTo(100L);
@@ -216,14 +216,14 @@ public class TradesServiceTest {
 		ChatRooms chatRoom = new ChatRooms();
 		ReflectionTestUtils.setField(chatRoom, "id", 200L);
 		when(chatRoomsRepository.findByTrade(trade)).thenReturn(Optional.of(chatRoom));
-		doNothing().when(chatNotificationService)
+		doNothing().when(chatSendService)
 			.sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.CANCEL), any());
 
 		// When & Then
 		assertDoesNotThrow(() -> tradesService.cancelTrade(tradeId));
 		verify(tradesRepository).delete(trade);
 		verify(chatRoomsRepository).findByTrade(trade);
-		verify(chatNotificationService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.CANCEL), any());
+		verify(chatSendService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.CANCEL), any());
 	}
 
 	@Test
@@ -250,7 +250,7 @@ public class TradesServiceTest {
 		ChatRooms chatRoom = new ChatRooms(targetGood, requester, trade);
 		ReflectionTestUtils.setField(chatRoom, "id", 300L);
 		when(chatRoomsRepository.findByTrade(trade)).thenReturn(Optional.of(chatRoom));
-		doNothing().when(chatNotificationService)
+		doNothing().when(chatSendService)
 			.sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.ACCEPT), eq(requestedGood));
 
 		// When
@@ -261,7 +261,7 @@ public class TradesServiceTest {
 		assertThat(trade.getStatus()).isEqualTo(TradeStatus.INPROGRESS);
 		verify(tradesRepository).rejectOtherTrades(targetGood, tradesId);
 		verify(chatRoomsRepository).findByTrade(trade);
-		verify(chatNotificationService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.ACCEPT),
+		verify(chatSendService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.ACCEPT),
 			eq(requestedGood));
 		// goods 상태도 변경되었는지 (RESERVED) – 실제 setter 호출 후 goodsRepository.save() 호출 여부를 검증
 		verify(goodsRepository).save(targetGood);
@@ -395,7 +395,7 @@ public class TradesServiceTest {
 		ChatRooms chatRoom = new ChatRooms(targetGood, requester, trade);
 		ReflectionTestUtils.setField(chatRoom, "id", 400L);
 		when(chatRoomsRepository.findByTrade(trade)).thenReturn(Optional.of(chatRoom));
-		doNothing().when(chatNotificationService)
+		doNothing().when(chatSendService)
 			.sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REJECT), eq(requestedGood));
 
 		// When
@@ -404,7 +404,7 @@ public class TradesServiceTest {
 		// Then
 		assertThat(trade.getStatus()).isEqualTo(TradeStatus.REJECTED);
 		verify(chatRoomsRepository).findByTrade(trade);
-		verify(chatNotificationService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REJECT),
+		verify(chatSendService).sendTradeRequestChat(eq(chatRoom.getId()), eq(ChatType.REJECT),
 			eq(requestedGood));
 		verify(notificationEventPublisher).publishNotification(eq(requestedGood.getUser().getUsersId()),
 			eq(NotificationType.REJECTED), eq(targetGood.getId()));

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -391,7 +391,6 @@ public class TradesServiceTest {
 		when(tradesRepository.findById(tradesId)).thenReturn(Optional.of(trade));
 		when(currentUserService.getCurrentUser()).thenReturn(target);
 
-		// 모킹: 채팅방가 존재하는 경우
 		ChatRooms chatRoom = new ChatRooms(targetGood, requester, trade);
 		ReflectionTestUtils.setField(chatRoom, "id", 400L);
 		when(chatRoomsRepository.findByTrade(trade)).thenReturn(Optional.of(chatRoom));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #99 

## 📝 작업 내용

> 안읽은 메세지 개수 구현, 채팅방 물건 조회를 채팅방 정보 조회로 변경, 
> ChatNotificationService 메소드명 변경, 테스트 코드 수정

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 필드 추가한게 있어서 확인 후에 머지는 제가 하겠습니다!
