### PR TITLE
[feat] 물건 상세 조회 api에서 swap 조회 후, 응답에 같이 반환

### DIFF
--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
 	TRADE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "거래에 대한 권한이 없습니다."),
 	DUPLICATE_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "이미 해당 물건에 스왑 요청한 내역이 있습니다."),
+	TRADE_ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "이미 해당 거래에 대해 요청을 받은 건이 존재합니다."),
 	MAXIMUM_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "가능한 스왑 요청 횟수를 초과하였습니다."),
 
 	// chat error

--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/user/auth/logout",
 		"/api/all/auth/info",
 		"/api/all/sample",
-		"api/all/goods",
 		"/ws",
 		"/docs",
 		"/swagger-ui",

--- a/src/main/java/com/example/swapit/domain/dto/good/GoodsDetailDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/GoodsDetailDto.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GoodsDetailDto {
-
 	private Long goodsId;
 	private UserProfileDto user;
 	private String category;
@@ -27,9 +26,11 @@ public class GoodsDetailDto {
 	private String placeName;
 	private long viewCount;
 	private List<GoodsImageDto> images;
+	private TradeInGoodDetailDto trade;
 	private LocalDateTime createdAt;
 
-	public static GoodsDetailDto of(Goods good, UserProfileDto userProfileDto, List<GoodsImageDto> images) {
+	public static GoodsDetailDto of(Goods good, UserProfileDto userProfileDto, List<GoodsImageDto> images,
+		TradeInGoodDetailDto trade) {
 		return GoodsDetailDto.builder()
 			.goodsId(good.getId())
 			.user(userProfileDto)
@@ -42,6 +43,7 @@ public class GoodsDetailDto {
 			.placeName(good.getPlaceName())
 			.viewCount(good.getViewCount())
 			.images(images)
+			.trade(trade)
 			.createdAt(good.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/example/swapit/domain/dto/good/TradeInGoodDetailDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/TradeInGoodDetailDto.java
@@ -1,0 +1,19 @@
+package com.example.swapit.domain.dto.good;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TradeInGoodDetailDto {
+	private Long tradesId;
+	private boolean isRequester;
+	private String status;
+
+	@JsonProperty("isRequester")
+	public boolean getIsRequester() {
+		return isRequester;
+	}
+}

--- a/src/main/java/com/example/swapit/domain/dto/good/TradeInGoodDetailDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/TradeInGoodDetailDto.java
@@ -11,6 +11,7 @@ public class TradeInGoodDetailDto {
 	private Long tradesId;
 	private boolean isRequester;
 	private String status;
+	private Long relatedGoodsId;
 
 	@JsonProperty("isRequester")
 	public boolean getIsRequester() {

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -1,6 +1,7 @@
 package com.example.swapit.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -44,4 +45,11 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 
 	boolean existsByRequestedGoodsAndTargetGoodsAndStatusNot(Goods requestedGoods, Goods targetGoods,
 		TradeStatus status);
+
+	@Query(""" 
+		SELECT t FROM Trades t 
+		WHERE (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId) 
+		   OR (t.requestedGoods.id = :goodsId AND t.targetGoods.user.usersId = :userId)
+		ORDER BY t.updatedAt DESC""")
+	Optional<Trades> findUserRelatedTrade(@Param("goodsId") Long goodsId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -47,8 +47,8 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 		TradeStatus status);
 
 	@Query(""" 
-		SELECT t FROM Trades t 
-		WHERE (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId) 
+		SELECT t FROM Trades t
+		WHERE (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId)
 		   OR (t.requestedGoods.id = :goodsId AND t.targetGoods.user.usersId = :userId)
 		ORDER BY t.updatedAt DESC""")
 	Optional<Trades> findUserRelatedTrade(@Param("goodsId") Long goodsId, @Param("userId") Long userId);

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -1,7 +1,6 @@
 package com.example.swapit.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.TradeStatus;
 import com.example.swapit.domain.Trades;
-import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dao.TradeGoodsDao;
 import com.example.swapit.domain.dto.trade.InProgressCountDto;
 import com.example.swapit.domain.dto.trade.TradeCountProjection;
@@ -25,27 +23,25 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 	void rejectOtherTrades(@Param("targetGoods") Goods targetGoods, @Param("acceptedTradeId") Long acceptedTradeId);
 
 	@Query("SELECT t.targetGoods.id AS goodsId, COALESCE(COUNT(t), 0) AS tradeCount "
-		   + "FROM Trades t "
-		   + "WHERE t.targetGoods.id IN :goodsIds "
-		   + "GROUP BY t.targetGoods.id")
+		+ "FROM Trades t "
+		+ "WHERE t.targetGoods.id IN :goodsIds "
+		+ "GROUP BY t.targetGoods.id")
 	List<TradeCountProjection> findTradeCountByGoodsIds(@Param("goodsIds") List<Long> goodsIds);
 
 	@Query("SELECT new com.example.swapit.domain.dao.TradeGoodsDao(t.targetGoods, t.requestedGoods, t.id) "
-		   + "FROM Trades t "
-		   + "WHERE t.requestedGoods.user.usersId = :userId")
+		+ "FROM Trades t "
+		+ "WHERE t.requestedGoods.user.usersId = :userId")
 	List<TradeGoodsDao> findMyRequests(@Param("userId") Long userId);
 
 	@Query("SELECT t.requestedGoods FROM Trades t WHERE t.targetGoods.id = :goodsId ORDER BY t.createdAt DESC")
 	List<Goods> findGoodsRequests(@Param("goodsId") Long goodsId);
 
-	Optional<Trades> findByRequestedGoodsUserAndTargetGoods(Users requester, Goods targetGoods);
-
-	boolean existsByTargetGoodsAndStatusNot(Goods targetGoods, TradeStatus status);
-
 	@Query("SELECT new com.example.swapit.domain.dto.trade.InProgressCountDto(t.targetGoods.id, COUNT(t)) "
-		   + "FROM Trades t "
-		   + "WHERE t.targetGoods.id IN :goodsIds AND t.status = 'INPROGRESS' "
-		   + "GROUP BY t.targetGoods.id")
+		+ "FROM Trades t "
+		+ "WHERE t.targetGoods.id IN :goodsIds AND t.status = 'INPROGRESS' "
+		+ "GROUP BY t.targetGoods.id")
 	List<InProgressCountDto> findInProgressCountByGoodsIds(@Param("goodsIds") List<Long> goodsIds);
 
+	boolean existsByRequestedGoodsAndTargetGoodsAndStatusNot(Goods requestedGoods, Goods targetGoods,
+		TradeStatus status);
 }

--- a/src/main/java/com/example/swapit/service/CurrentUserService.java
+++ b/src/main/java/com/example/swapit/service/CurrentUserService.java
@@ -1,7 +1,11 @@
 package com.example.swapit.service;
 
+import java.util.Optional;
+
 import com.example.swapit.domain.Users;
 
 public interface CurrentUserService {
-	public Users getCurrentUser();
+	Users getCurrentUser();
+
+	Optional<Users> getCurrentUserOptional();
 }

--- a/src/main/java/com/example/swapit/service/CurrentUserServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/CurrentUserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.swapit.service;
 
+import java.util.Optional;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -28,5 +30,15 @@ public class CurrentUserServiceImpl implements CurrentUserService {
 		} else { // principal이 "anonymousUser" 또는 null일 수 있음.
 			throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
 		}
+	}
+
+	public Optional<Users> getCurrentUserOptional() {
+		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+		if (principal instanceof UserDetails) {
+			String email = ((UserDetails)principal).getUsername();
+			return usersRepository.findByEmail(email); // Optional 반환
+		}
+		return Optional.empty(); // 인증되지 않은 경우 빈 Optional 반환
 	}
 }

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.swapit.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
@@ -14,6 +15,7 @@ import com.example.swapit.domain.Categories;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.GoodsTradeStatus;
+import com.example.swapit.domain.Trades;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.Dto;
 import com.example.swapit.domain.dto.UserProfileDto;
@@ -23,10 +25,12 @@ import com.example.swapit.domain.dto.good.GoodsImageDto;
 import com.example.swapit.domain.dto.good.GoodsListDto;
 import com.example.swapit.domain.dto.good.GoodsRequestDto;
 import com.example.swapit.domain.dto.good.MyGoodDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
+import com.example.swapit.repository.TradesRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +48,7 @@ public class GoodsServiceImpl implements GoodsService {
 	private final GoodsImagesRepository goodsImagesRepository;
 	private final ReviewRepository reviewRepository;
 	private final AwsS3Service awsS3Service;
+	private final TradesRepository tradesRepository;
 
 	@Value("${cloud.aws.cloudfront.url}")
 	private String cdnUrl;
@@ -130,7 +135,29 @@ public class GoodsServiceImpl implements GoodsService {
 			.stream()
 			.map(image -> new GoodsImageDto(image.getId(), cdnUrl + image.getS3Key()))
 			.toList();
-		return GoodsDetailDto.of(good, userProfileDto, photos);
+
+		// 현재 유저 확인 후, TradeInGoodDetailDto 구성.
+		TradeInGoodDetailDto tradeInGoodDetailDto = currentUserService.getCurrentUserOptional()
+			.map(user -> getTradeInDetail(goodsId, user.getUsersId()))
+			.orElse(null);
+
+		return GoodsDetailDto.of(good, userProfileDto, photos, tradeInGoodDetailDto);
+	}
+
+	/**
+	 *  현재 사용자가 관련된 거래가 있는지 확인
+	 */
+	private TradeInGoodDetailDto getTradeInDetail(Long goodsId, Long userId) {
+		Optional<Trades> tradesOpt = tradesRepository.findUserRelatedTrade(goodsId, userId);
+		if (tradesOpt.isEmpty()) {
+			return null;
+		}
+
+		Trades trade = tradesOpt.get();
+		// 현재 사용자가 거래 요청자인지 확인
+		boolean isRequester = trade.getRequestedGoods().getUser().getUsersId().equals(userId);
+
+		return new TradeInGoodDetailDto(trade.getId(), isRequester, trade.getStatus().name());
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -157,7 +157,11 @@ public class GoodsServiceImpl implements GoodsService {
 		// 현재 사용자가 거래 요청자인지 확인
 		boolean isRequester = trade.getRequestedGoods().getUser().getUsersId().equals(userId);
 
-		return new TradeInGoodDetailDto(trade.getId(), isRequester, trade.getStatus().name());
+		Long relatedGoodsId = trade.getTargetGoods().getId().equals(goodsId)
+			? trade.getRequestedGoods().getId()
+			: trade.getTargetGoods().getId();
+
+		return new TradeInGoodDetailDto(trade.getId(), isRequester, trade.getStatus().name(), relatedGoodsId);
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -67,7 +67,7 @@ public class TradesServiceImpl implements TradesService {
 		// requestedGoods <-> targetGoods가 바뀌어서 요청된 건은 없는지 검증
 		if (tradesRepository.existsByRequestedGoodsAndTargetGoodsAndStatusNot(targetGoods, requestedGoods,
 			TradeStatus.REJECTED)) {
-			throw new CustomException(ErrorCode.TRADE_ALREADY_REQUESTED);
+			return Result.fail(ErrorCode.TRADE_ALREADY_REQUESTED.getMessage());
 		}
 
 		// 최대 PENDING 요청 제한 체크

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -64,6 +64,12 @@ public class TradesServiceImpl implements TradesService {
 		Goods targetGoods = goodsRepository.findById(tradesRequestDto.getTargetGoodsId())
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 
+		// requestedGoods <-> targetGoods가 바뀌어서 요청된 건은 없는지 검증
+		if (tradesRepository.existsByRequestedGoodsAndTargetGoodsAndStatusNot(targetGoods, requestedGoods,
+			TradeStatus.REJECTED)) {
+			throw new CustomException(ErrorCode.TRADE_ALREADY_REQUESTED);
+		}
+
 		// 최대 PENDING 요청 제한 체크
 		long count = tradesRepository.countByTargetGoodsIdAndStatus(tradesRequestDto.getTargetGoodsId(),
 			TradeStatus.PENDING);

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.example.swapit.domain.GoodsTradeStatus;
+import com.example.swapit.domain.TradeStatus;
 import com.example.swapit.domain.dto.Dto;
 import com.example.swapit.domain.dto.UserProfileDto;
 import com.example.swapit.domain.dto.good.GoodsDetailDto;
@@ -33,6 +34,7 @@ import com.example.swapit.domain.dto.good.GoodsImageDto;
 import com.example.swapit.domain.dto.good.GoodsListDto;
 import com.example.swapit.domain.dto.good.GoodsRequestDto;
 import com.example.swapit.domain.dto.good.MyGoodDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.service.GoodsService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -89,6 +91,7 @@ class GoodsControllerTest {
 	@DisplayName("물건 상세 조회 테스트")
 	void getDetailGood() throws Exception {
 		// given
+		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(2L, true, TradeStatus.PENDING.name());
 		GoodsDetailDto mockGoodsDetail = new GoodsDetailDto(
 			1L,
 			new UserProfileDto(1L, "testUser", "profileImage", 4.8),
@@ -101,10 +104,10 @@ class GoodsControllerTest {
 			"서울 강남구",
 			120,
 			List.of(new GoodsImageDto(1L, "imageUrl")),
+			trade,
 			LocalDateTime.now()
 		);
 
-		// given(goodsService.getGoodDetail(anyLong())).willReturn(mockGoodsDetail);
 		given(goodsService.getGoodDetail(1L)).willReturn(mockGoodsDetail);
 
 		mockMvc.perform(get("/api/all/goods/{goodsId}", 1L))
@@ -125,7 +128,11 @@ class GoodsControllerTest {
 			.andExpect(jsonPath("$.results.goodsTradeStatus").value("판매 중"))
 			.andExpect(jsonPath("$.results.placeName").value("서울 강남구"))
 			.andExpect(jsonPath("$.results.viewCount").value(120))
-			.andExpect(jsonPath("$.results.images").isArray());
+			.andExpect(jsonPath("$.results.images").isArray())
+			.andExpect(jsonPath("$.results.trade.tradesId").value(2L))
+			.andExpect(jsonPath("$.results.trade.isRequester").value(true))
+			.andExpect(jsonPath("$.results.trade.status").value("PENDING"));
+
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -91,7 +91,7 @@ class GoodsControllerTest {
 	@DisplayName("물건 상세 조회 테스트")
 	void getDetailGood() throws Exception {
 		// given
-		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(2L, true, TradeStatus.PENDING.name());
+		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(2L, true, TradeStatus.PENDING.name(), 2L);
 		GoodsDetailDto mockGoodsDetail = new GoodsDetailDto(
 			1L,
 			new UserProfileDto(1L, "testUser", "profileImage", 4.8),
@@ -131,7 +131,8 @@ class GoodsControllerTest {
 			.andExpect(jsonPath("$.results.images").isArray())
 			.andExpect(jsonPath("$.results.trade.tradesId").value(2L))
 			.andExpect(jsonPath("$.results.trade.isRequester").value(true))
-			.andExpect(jsonPath("$.results.trade.status").value("PENDING"));
+			.andExpect(jsonPath("$.results.trade.status").value("PENDING"))
+			.andExpect(jsonPath("$.results.trade.relatedGoodsId").value(2L));
 
 	}
 

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -205,6 +205,43 @@ public class TradesServiceTest {
 	}
 
 	@Test
+	@DisplayName("거래 요청 실패 - requestedGoods <-> targetGoods 반대로 이미 있을 때 요청 실패")
+	void requestTrade_ShouldThrowException_WhenTradeAlreadyRequested() {
+		// given
+		Users requester = Users.builder()
+			.email("email")
+			.build();
+		Goods requestedGoods = Goods.builder()
+			.user(requester)
+			.build();
+
+		Users target = Users.builder()
+			.email("email")
+			.build();
+		Goods targetGoods = Goods.builder()
+			.user(target)
+			.build();
+
+		Long requestedGoodsId = 1L;
+		Long targetGoodsId = 2L;
+
+		TradesRequestDto tradesRequestDto = new TradesRequestDto(requestedGoodsId, targetGoodsId);
+
+		when(goodsRepository.findById(requestedGoodsId)).thenReturn(Optional.of(requestedGoods));
+		when(goodsRepository.findById(targetGoodsId)).thenReturn(Optional.of(targetGoods));
+		when(tradesRepository.existsByRequestedGoodsAndTargetGoodsAndStatusNot(targetGoods, requestedGoods,
+			TradeStatus.REJECTED))
+			.thenReturn(true);
+
+		// when
+		Result<Long> result = tradesService.requestTrade(tradesRequestDto);
+
+		// when & then
+		assertFalse(result.isSuccess());
+		assertEquals(ErrorCode.TRADE_ALREADY_REQUESTED.getMessage(), result.getMessage());
+	}
+
+	@Test
 	@DisplayName("거래 요청 취소 성공")
 	void cancelTradeSuccess() {
 		// Given


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #102 

## 📝 작업 내용
- 기존의 jwtFilter에서 `/api/all/goods` 를 포함하는 api로 넘어오면 jwtFilter를 통과하도록 했지만, 로그인 한 유저라면 유저 정보를 가져올 수 있도록 filter를 거치도록 변경
- CurrentUserService에서 로그인 상관없이 유저 정보를 Optional로 받아오는 메서드 추가
- 물건 상세 조회 api에서 연관된 Trades를 조회해 response dto에 같이 담아서 반환하도록 추가.
  - 거래 dto 생성 (물건 상세 조회 사용)
- 거래 중복 test code 추가 작성
- 거래 dto에 현재 보고 있는 물건이 아닌 연관된 물건 id 추가 -> 안드로이드에서 버튼으로 연관된 물건 매핑

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
없습니다!
