### PR TITLE
hotfix : spring 서버 내부에서 hibernate가 createdAt을 설정할 때 타임존을 seoul로 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,9 +4,15 @@ spring:
 
   profiles:
     active:
-      - prd   # 로컬에서는 dev로, 테스트할 때는 test로 변경해서 사용.
+      - dev   # 로컬에서는 dev로, 테스트할 때는 test로 변경해서 사용.
     include:
       - jwt
       - aws
       - mail
       - doc
+
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
 
   profiles:
     active:
-      - dev   # 로컬에서는 dev로, 테스트할 때는 test로 변경해서 사용.
+      - prd   # 로컬에서는 dev로, 테스트할 때는 test로 변경해서 사용.
     include:
       - jwt
       - aws


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #106 

## 📝 작업 내용
- spring 서버 내부에서 타임존을 서울로 설정

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
없습니다!
