### PR TITLE
[hotfix] spring 서버 타임존 강제적용

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'GRADLE_OPTS="-Duser.timezone=Asia/Seoul" ./gradlew clean openapi3 bootJar'
+                sh 'GRADLE_OPTS="-Duser.timezone=Asia/Seoul" ./gradlew clean bootJar'
             }
         }
         stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh './gradlew clean bootJar -Duser.timezone=Asia/Seoul'
+                sh 'GRADLE_OPTS="-Duser.timezone=Asia/Seoul" ./gradlew clean bootJar'
             }
         }
         stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh './gradlew clean bootJar'
+                sh './gradlew clean bootJar -Duser.timezone=Asia/Seoul'
             }
         }
         stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'GRADLE_OPTS="-Duser.timezone=Asia/Seoul" ./gradlew clean bootJar'
+                sh 'GRADLE_OPTS="-Duser.timezone=Asia/Seoul" ./gradlew clean openapi3 bootJar'
             }
         }
         stage('Deploy') {

--- a/src/main/java/com/example/swapit/SwapitApplication.java
+++ b/src/main/java/com/example/swapit/SwapitApplication.java
@@ -1,13 +1,25 @@
 package com.example.swapit;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
 public class SwapitApplication {
+
+	@PostConstruct
+	public void init() { // JVM 타임존 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+		log.info("JVM TimeZone Set to: {}", TimeZone.getDefault().getID());
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(SwapitApplication.class, args);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#106 

## 📝 작업 내용
- JVM의 타임존을 명시적으로 서울로 강제 설정
- 젠킨스 서버 타임존 상관없이 빌드, 배포를 타임존 적용하여 빌드 배포 되도록 설정

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)
없습니다!
