### PR TITLE
[fix] 채팅방 목록 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/example/swapit/repository/ChatRoomsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatRoomsRepository.java
@@ -17,6 +17,7 @@ public interface ChatRoomsRepository extends JpaRepository<ChatRooms, Long> {
 	@Query("""
 		SELECT c
 		FROM ChatRooms c
+		  LEFT JOIN c.goods g
 		  LEFT JOIN c.trade t
 		  LEFT JOIN t.requestedGoods rg
 		  LEFT JOIN t.targetGoods tg
@@ -24,7 +25,10 @@ public interface ChatRoomsRepository extends JpaRepository<ChatRooms, Long> {
 		WHERE
 		  (
 		    c.trade IS NULL
-		    AND c.inviter.id = :myId
+		    AND (
+		      c.inviter.id = :myId
+		      OR g.user.id = :myId
+		    )
 		  )
 		  OR
 		  (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없습니다!

## 📝 작업 내용

> 채팅방 목록 조회 시, 거래가 없을 경우에 내가 채팅방의 초대자이거나 물건의 주인일 때 조회되도록 조건 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 채팅방에서 내가 무조건 초대자이거나 물건의 주인인게 맞는거죠?? 해당 조건이 없어서 초대자가 아닐 경우에 조회가 안되고 있었네요.. 혹시 모르니깐 조건 한번 더 확인 부탁드립니다!
