### PR TITLE
[feat] 구글, 카카오 회원 탈퇴 신청

### DIFF
--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 	INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
 	GET_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "사용자 정보 조회에 실패했습니다."),
 	LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
+	SOCIAL_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "소셜 연결 해제에 실패했습니다."),
 
 	// trades error
 	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),

--- a/src/main/java/com/example/swapit/controller/AuthController.java
+++ b/src/main/java/com/example/swapit/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.swapit.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.TokenDTO;
 import com.example.swapit.domain.dto.UserResponseDTO;
+import com.example.swapit.domain.dto.WithdrawDto;
 import com.example.swapit.service.AuthService;
 
 import lombok.RequiredArgsConstructor;
@@ -43,6 +45,20 @@ public class AuthController {
 	@PostMapping("/user/auth/logout")
 	public ApiResponse<Void> logout(@RequestHeader("Authorization") String token) {
 		authService.deleteRefreshToken(token);
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/user/auth/withdraw/google")
+	public ApiResponse<Void> withdrawGoogle(@RequestHeader("X-Google-Token") String googleToken,
+		@RequestBody WithdrawDto dto) {
+		authService.withdrawGoogleUser(googleToken, dto.getReason());
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/user/auth/withdraw/kakao")
+	public ApiResponse<Void> withdrawKakao(@RequestHeader("X-Kakao-Token") String kakaoToken,
+		@RequestBody WithdrawDto dto) {
+		authService.withdrawKakaoUser(kakaoToken, dto.getReason());
 		return ApiResponse.success();
 	}
 }

--- a/src/main/java/com/example/swapit/domain/ChatRooms.java
+++ b/src/main/java/com/example/swapit/domain/ChatRooms.java
@@ -1,5 +1,8 @@
 package com.example.swapit.domain;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,6 +24,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE chatrooms SET is_deleted = true WHERE chatrooms_id = ?")
+@SQLRestriction("is_deleted = false")
 @Table(name = "chatrooms",
 	uniqueConstraints = @UniqueConstraint(columnNames = {"goods_id, inviter_id"})
 )
@@ -51,6 +56,9 @@ public class ChatRooms {
 	@Setter
 	@Column(name = "not_inviter_last_read_id", nullable = false)
 	private Long notInviterLastReadId;
+
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
 	public ChatRooms(Goods goods, Users inviter, Trades trade) {
 		this.goods = goods;

--- a/src/main/java/com/example/swapit/domain/Chats.java
+++ b/src/main/java/com/example/swapit/domain/Chats.java
@@ -2,6 +2,8 @@ package com.example.swapit.domain;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -26,6 +28,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE chats SET is_deleted = true WHERE chats_id = ?")
+@SQLRestriction("is_deleted = false")
 @Table(name = "chats")
 public class Chats {
 
@@ -55,6 +59,9 @@ public class Chats {
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
 	@Builder
 	public Chats(ChatRooms chatRooms, Users sender, ChatType chatType, String content, Long goodsId) {

--- a/src/main/java/com/example/swapit/domain/Notifications.java
+++ b/src/main/java/com/example/swapit/domain/Notifications.java
@@ -1,5 +1,6 @@
 package com.example.swapit.domain;
 
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.Column;
@@ -23,6 +24,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@SQLDelete(sql = "UPDATE notifications SET is_deleted = true WHERE notifications_id = ?")
 @SQLRestriction("is_read = false")
 @Table(name = "notifications")
 public class Notifications extends BaseEntity {

--- a/src/main/java/com/example/swapit/domain/Users.java
+++ b/src/main/java/com/example/swapit/domain/Users.java
@@ -3,6 +3,9 @@ package com.example.swapit.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +25,8 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE users_id = ?")
+@SQLRestriction("is_deleted = false")
 @Table(name = "users")
 public class Users {
 	@Id
@@ -45,6 +50,9 @@ public class Users {
 
 	@Column(name = "role", columnDefinition = "VARCHAR(20)", nullable = false)
 	private String role;
+
+	@Column(nullable = false)
+	private boolean isDeleted = false;
 
 	@Builder.Default
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/swapit/domain/WithdrawReasons.java
+++ b/src/main/java/com/example/swapit/domain/WithdrawReasons.java
@@ -1,0 +1,48 @@
+package com.example.swapit.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "withdraw_reasons")
+@EntityListeners(AuditingEntityListener.class)
+public class WithdrawReasons {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "reason_id", columnDefinition = "BIGINT", nullable = false)
+	private Long reasonId;
+
+	@Column(name = "reason", columnDefinition = "VARCHAR(200)", nullable = false)
+	private String reason;
+
+	@OneToOne
+	@JoinColumn(name = "users_id", nullable = false)
+	private Users users;
+
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	public WithdrawReasons(String reason, Users users) {
+		this.reason = reason;
+		this.users = users;
+	}
+}

--- a/src/main/java/com/example/swapit/domain/WithdrawReasons.java
+++ b/src/main/java/com/example/swapit/domain/WithdrawReasons.java
@@ -11,8 +11,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,22 +25,21 @@ import lombok.NoArgsConstructor;
 public class WithdrawReasons {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "reason_id", columnDefinition = "BIGINT", nullable = false)
-	private Long reasonId;
+	@Column(name = "reasons_id", columnDefinition = "BIGINT", nullable = false)
+	private Long id;
 
 	@Column(name = "reason", columnDefinition = "VARCHAR(200)", nullable = false)
 	private String reason;
 
-	@OneToOne
-	@JoinColumn(name = "users_id", nullable = false)
-	private Users users;
+	@Column(name = "users_id", columnDefinition = "BIGINT", nullable = false)
+	private Long usersId;
 
 	@CreatedDate
 	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-	public WithdrawReasons(String reason, Users users) {
+	public WithdrawReasons(String reason, Long usersId) {
 		this.reason = reason;
-		this.users = users;
+		this.usersId = usersId;
 	}
 }

--- a/src/main/java/com/example/swapit/domain/dto/WithdrawDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/WithdrawDto.java
@@ -1,0 +1,8 @@
+package com.example.swapit.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public class WithdrawDto {
+	private String reason;
+}

--- a/src/main/java/com/example/swapit/repository/ChatsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatsRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.example.swapit.domain.Chats;
+import com.example.swapit.domain.Users;
 
 public interface ChatsRepository extends JpaRepository<Chats, Long> {
 
@@ -28,4 +29,6 @@ public interface ChatsRepository extends JpaRepository<Chats, Long> {
 		   + "WHERE c.chatRooms.id = :chatRoomsId "
 		   + "AND c.id > :lastReadId")
 	long findUnreadChatCount(long chatRoomsId, long lastReadId);
+
+	void deleteAllBySender(Users sender);
 }

--- a/src/main/java/com/example/swapit/repository/ChatsRepository.java
+++ b/src/main/java/com/example/swapit/repository/ChatsRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -30,5 +31,6 @@ public interface ChatsRepository extends JpaRepository<Chats, Long> {
 		   + "AND c.id > :lastReadId")
 	long findUnreadChatCount(long chatRoomsId, long lastReadId);
 
+	@Modifying
 	void deleteAllBySender(Users sender);
 }

--- a/src/main/java/com/example/swapit/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/swapit/repository/FcmTokenRepository.java
@@ -3,6 +3,7 @@ package com.example.swapit.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import com.example.swapit.domain.FcmToken;
 import com.example.swapit.domain.Users;
@@ -10,5 +11,6 @@ import com.example.swapit.domain.Users;
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 	Optional<FcmToken> findByUser(Users user);
 
+	@Modifying
 	void deleteByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/swapit/repository/FcmTokenRepository.java
@@ -9,4 +9,6 @@ import com.example.swapit.domain.Users;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 	Optional<FcmToken> findByUser(Users user);
+
+	void deleteByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/GoodsImagesRepository.java
+++ b/src/main/java/com/example/swapit/repository/GoodsImagesRepository.java
@@ -12,4 +12,6 @@ public interface GoodsImagesRepository extends JpaRepository<GoodsImages, Long> 
 	List<GoodsImages> findByGood(Goods good);
 
 	Optional<GoodsImages> findFirstByGoodOrderByIdAsc(Goods good);
+
+	List<GoodsImages> findByGoodIn(List<Goods> goods);
 }

--- a/src/main/java/com/example/swapit/repository/NotificationRepository.java
+++ b/src/main/java/com/example/swapit/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.example.swapit.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +17,6 @@ public interface NotificationRepository extends JpaRepository<Notifications, Lon
 	@Query("SELECT n FROM Notifications n WHERE n.user = :user AND n.isRead = false ORDER BY n.createdAt DESC")
 	List<Notifications> findByUserAndReadNotOrderByCreatedAtDesc(@Param("user") Users user);
 
+	@Modifying
 	void deleteAllByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/NotificationRepository.java
+++ b/src/main/java/com/example/swapit/repository/NotificationRepository.java
@@ -15,4 +15,6 @@ import io.lettuce.core.dynamic.annotation.Param;
 public interface NotificationRepository extends JpaRepository<Notifications, Long> {
 	@Query("SELECT n FROM Notifications n WHERE n.user = :user AND n.isRead = false ORDER BY n.createdAt DESC")
 	List<Notifications> findByUserAndReadNotOrderByCreatedAtDesc(@Param("user") Users user);
+
+	void deleteAllByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -19,4 +19,6 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 	List<Reviews> findTop5ByRevieweeOrderByCreatedAtDesc(Users reviewee);
 
 	long countByReviewee(Users reviewee);
+
+	void deleteAllByWriterOrReviewee(Users writer, Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/ReviewRepository.java
+++ b/src/main/java/com/example/swapit/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package com.example.swapit.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import com.example.swapit.domain.Reviews;
@@ -20,5 +21,6 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long> {
 
 	long countByReviewee(Users reviewee);
 
+	@Modifying
 	void deleteAllByWriterOrReviewee(Users writer, Users reviewee);
 }

--- a/src/main/java/com/example/swapit/repository/TokensRepository.java
+++ b/src/main/java/com/example/swapit/repository/TokensRepository.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.swapit.domain.Tokens;
+import com.example.swapit.domain.Users;
 
 public interface TokensRepository extends JpaRepository<Tokens, Long> {
 	Optional<Tokens> findByUserEmail(String email);
 
 	Optional<Tokens> findByRefreshToken(String refreshToken);
+
+	void deleteByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/TokensRepository.java
+++ b/src/main/java/com/example/swapit/repository/TokensRepository.java
@@ -3,6 +3,7 @@ package com.example.swapit.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import com.example.swapit.domain.Tokens;
 import com.example.swapit.domain.Users;
@@ -12,5 +13,6 @@ public interface TokensRepository extends JpaRepository<Tokens, Long> {
 
 	Optional<Tokens> findByRefreshToken(String refreshToken);
 
+	@Modifying
 	void deleteByUser(Users users);
 }

--- a/src/main/java/com/example/swapit/repository/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/TradesRepository.java
@@ -57,4 +57,10 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 	boolean existsByTargetGoodsAndRequestedGoodsUserAndStatusNot(Goods targetGoods, Users requestedUser,
 		TradeStatus status);
 
+	@Query("""
+		SELECT t FROM Trades t
+		WHERE (t.requestedGoods.user.usersId = :userId)
+		OR (t.targetGoods.user.usersId = :userId)
+		""")
+	List<Trades> findAllByUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/swapit/repository/WithdrawReasonsRepository.java
+++ b/src/main/java/com/example/swapit/repository/WithdrawReasonsRepository.java
@@ -1,0 +1,8 @@
+package com.example.swapit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.swapit.domain.WithdrawReasons;
+
+public interface WithdrawReasonsRepository extends JpaRepository<WithdrawReasons, Long> {
+}

--- a/src/main/java/com/example/swapit/service/AuthService.java
+++ b/src/main/java/com/example/swapit/service/AuthService.java
@@ -18,4 +18,8 @@ public interface AuthService {
 	Users getKakaoUserInfo(String accessToken);
 
 	void deleteRefreshToken(String token);
+
+	void withdrawGoogleUser(String googleToken, String reason);
+
+	void withdrawKakaoUser(String kakaoToken, String reason);
 }

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.swapit.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -63,6 +64,7 @@ public class AuthServiceImpl implements AuthService {
 	private final GoodsImagesRepository goodsImagesRepository;
 
 	private final RestTemplate restTemplate;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	private static final String GOOGLE_LOGIN_INFO = "google";
 	private static final String KAKAO_LOGIN_INFO = "kakao";
@@ -283,13 +285,15 @@ public class AuthServiceImpl implements AuthService {
 		usersRepository.delete(user);
 
 		// DB 트랜잭션 이후 S3 삭제 수행
-		deleteFilesFromS3AfterTransaction(goodsImagesList);
+		applicationEventPublisher.publishEvent(
+			new UserWithdrawCompletedEvent(this, goodsImagesList, user));
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void deleteFilesFromS3AfterTransaction(List<GoodsImages> images) {
+	public void handleUserWithdrawCompletedEvent(UserWithdrawCompletedEvent event) {
 		try {
-			awsS3Service.deleteFilesFromS3(images);
+			awsS3Service.deleteFilesFromS3(event.getImages());
+			awsS3Service.deleteFileFromS3(event.getUser().getProfileImageUrl());
 		} catch (Exception e) {
 			log.error("S3 이미지 삭제 실패, 추후 재처리 필요", e);
 		}

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -215,6 +215,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
+	@Transactional
 	public void withdrawGoogleUser(String googleToken, String reason) {
 		RestTemplate restTemplate = new RestTemplate();
 		String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + googleToken;
@@ -231,6 +232,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
+	@Transactional
 	public void withdrawKakaoUser(String kakaoToken, String reason) {
 		RestTemplate restTemplate = new RestTemplate();
 		HttpHeaders headers = new HttpHeaders();
@@ -275,7 +277,7 @@ public class AuthServiceImpl implements AuthService {
 		goodsRepository.deleteAll(goodsList);
 
 		// 사유 저장
-		withdrawReasonsRepository.save(new WithdrawReasons(reason, user));
+		withdrawReasonsRepository.save(new WithdrawReasons(reason, user.getUsersId()));
 
 		// 사용자 삭제
 		usersRepository.delete(user);

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -1,36 +1,71 @@
 package com.example.swapit.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.client.RestTemplate;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.config.security.jwt.JwtProvider;
 import com.example.swapit.config.security.jwt.JwtService;
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.Users;
+import com.example.swapit.domain.WithdrawReasons;
 import com.example.swapit.domain.dto.TokenDTO;
 import com.example.swapit.domain.dto.UserResponseDTO;
+import com.example.swapit.repository.ChatRoomsRepository;
+import com.example.swapit.repository.ChatsRepository;
+import com.example.swapit.repository.FcmTokenRepository;
+import com.example.swapit.repository.GoodsImagesRepository;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.NotificationRepository;
+import com.example.swapit.repository.ReviewRepository;
 import com.example.swapit.repository.TokensRepository;
+import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.WithdrawReasonsRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthServiceImpl implements AuthService {
 	private final JwtProvider jwtProvider;
 	private final JwtService jwtService;
+	private final CurrentUserService currentUserService;
+	private final AwsS3Service awsS3Service;
+
 	private final UsersRepository usersRepository;
 	private final TokensRepository tokensRepository;
+	private final WithdrawReasonsRepository withdrawReasonsRepository;
+	private final FcmTokenRepository fcmTokenRepository;
+	private final NotificationRepository notificationRepository;
+	private final ReviewRepository reviewRepository;
+	private final ChatsRepository chatsRepository;
+	private final ChatRoomsRepository chatRoomsRepository;
+	private final TradesRepository tradesRepository;
+	private final GoodsRepository goodsRepository;
+	private final GoodsImagesRepository goodsImagesRepository;
+
 	private final RestTemplate restTemplate;
+
+	private static final String GOOGLE_LOGIN_INFO = "google";
+	private static final String KAKAO_LOGIN_INFO = "kakao";
 
 	@Override
 	public TokenDTO refresh(String token) {
@@ -130,7 +165,7 @@ public class AuthServiceImpl implements AuthService {
 						.nickname(nickname)
 						.email(email)
 						.profileImageUrl(profileImageUrl)
-						.loginInfo("google")
+						.loginInfo(GOOGLE_LOGIN_INFO)
 						.role(role)
 						.build();
 					return usersRepository.save(newUser);
@@ -163,7 +198,7 @@ public class AuthServiceImpl implements AuthService {
 						.nickname(nickname)
 						.email(email)
 						.profileImageUrl(profileImageUrl)
-						.loginInfo("kakao")
+						.loginInfo(KAKAO_LOGIN_INFO)
 						.role(role)
 						.build();
 					return usersRepository.save(newUser);
@@ -177,5 +212,84 @@ public class AuthServiceImpl implements AuthService {
 	public void deleteRefreshToken(String token) {
 		tokensRepository.findByRefreshToken(token.replace("Bearer ", ""))
 			.ifPresent(tokensRepository::delete);
+	}
+
+	@Override
+	public void withdrawGoogleUser(String googleToken, String reason) {
+		RestTemplate restTemplate = new RestTemplate();
+		String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + googleToken;
+
+		ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, null, String.class);
+
+		if (response.getStatusCode() != HttpStatus.OK) {
+			log.error("구글 연결 해제 실패");
+			throw new CustomException(ErrorCode.SOCIAL_UNLINK_FAILED);
+		}
+
+		log.info("구글 연결 해제 성공");
+		userWithdraw(reason);
+	}
+
+	@Override
+	public void withdrawKakaoUser(String kakaoToken, String reason) {
+		RestTemplate restTemplate = new RestTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(kakaoToken);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		String unlinkUrl = "https://kapi.kakao.com/v1/user/unlink";
+		ResponseEntity<String> response = restTemplate.exchange(unlinkUrl, HttpMethod.POST, entity, String.class);
+
+		if (response.getStatusCode() != HttpStatus.OK) {
+			log.error("카카오 연결 해제 실패");
+			throw new CustomException(ErrorCode.SOCIAL_UNLINK_FAILED);
+		}
+
+		log.info("카카오 연결 해제 성공");
+		userWithdraw(reason);
+	}
+
+	@Transactional
+	public void userWithdraw(String reason) {
+		Users user = currentUserService.getCurrentUser();
+
+		// FCM 토큰, 리프레시 토큰, 알림
+		fcmTokenRepository.deleteByUser(user);
+		tokensRepository.deleteByUser(user);
+		notificationRepository.deleteAllByUser(user);
+
+		// 후기, 채팅 메시지
+		reviewRepository.deleteAllByWriterOrReviewee(user, user);
+		chatsRepository.deleteAllBySender(user);
+
+		// 채팅방
+		chatRoomsRepository.deleteAll(chatRoomsRepository.findMyChatRooms(user.getUsersId()));
+
+		// 거래
+		tradesRepository.deleteAll(tradesRepository.findAllByUser(user.getUsersId()));
+
+		// 물건 및 물건 사진
+		List<Goods> goodsList = goodsRepository.findByUserOrderByCreatedAtDesc(user);
+		List<GoodsImages> goodsImagesList = goodsImagesRepository.findByGoodIn(goodsList);
+		goodsImagesRepository.deleteAll(goodsImagesList);
+		goodsRepository.deleteAll(goodsList);
+
+		// 사유 저장
+		withdrawReasonsRepository.save(new WithdrawReasons(reason, user));
+
+		// 사용자 삭제
+		usersRepository.delete(user);
+
+		// DB 트랜잭션 이후 S3 삭제 수행
+		deleteFilesFromS3AfterTransaction(goodsImagesList);
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void deleteFilesFromS3AfterTransaction(List<GoodsImages> images) {
+		try {
+			awsS3Service.deleteFilesFromS3(images);
+		} catch (Exception e) {
+			log.error("S3 이미지 삭제 실패, 추후 재처리 필요", e);
+		}
 	}
 }

--- a/src/main/java/com/example/swapit/service/AwsS3Service.java
+++ b/src/main/java/com/example/swapit/service/AwsS3Service.java
@@ -14,6 +14,8 @@ public interface AwsS3Service {
 
 	void deleteFile(GoodsImages image);
 
+	void deleteFileFromS3(String s3Key);
+
 	String updateUserProfileImage(Users user, MultipartFile file);
 
 	void deleteFilesFromS3(List<GoodsImages> images);

--- a/src/main/java/com/example/swapit/service/AwsS3Service.java
+++ b/src/main/java/com/example/swapit/service/AwsS3Service.java
@@ -15,4 +15,6 @@ public interface AwsS3Service {
 	void deleteFile(GoodsImages image);
 
 	String updateUserProfileImage(Users user, MultipartFile file);
+
+	void deleteFilesFromS3(List<GoodsImages> images);
 }

--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -107,7 +107,8 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 	/**
 	 * S3에서 파일 삭제
 	 */
-	private void deleteFileFromS3(String s3Key) {
+	@Override
+	public void deleteFileFromS3(String s3Key) {
 		DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
 			.bucket(bucketName)
 			.key(baseUrl + s3Key)
@@ -192,7 +193,6 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 			log.info("S3에서 {}개의 이미지가 성공적으로 삭제되었습니다.", objects.size());
 		} catch (S3Exception e) {
 			log.error("S3 이미지 삭제 중 오류 발생", e);
-			throw new RuntimeException("S3 이미지 삭제 실패", e);
 		}
 	}
 }

--- a/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AwsS3ServiceImpl.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
@@ -25,8 +26,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @Slf4j
 @Service
@@ -163,6 +168,31 @@ public class AwsS3ServiceImpl implements AwsS3Service {
 		} catch (IOException e) {
 			log.error("MIME 타입 감지 실패: {}", e.getMessage());
 			throw new CustomException(ErrorCode.IMAGE_READ_FAILED);
+		}
+	}
+
+	/**
+	 * S3에서 한 번에 여러 이미지 삭제
+	 */
+	@Override
+	public void deleteFilesFromS3(List<GoodsImages> images) {
+		List<ObjectIdentifier> objects = images.stream()
+			.map(image -> ObjectIdentifier.builder()
+				.key(baseUrl + image.getS3Key())
+				.build())
+			.collect(Collectors.toList());
+
+		DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+			.bucket(bucketName)
+			.delete(Delete.builder().objects(objects).build())
+			.build();
+
+		try {
+			s3Client.deleteObjects(deleteObjectsRequest);
+			log.info("S3에서 {}개의 이미지가 성공적으로 삭제되었습니다.", objects.size());
+		} catch (S3Exception e) {
+			log.error("S3 이미지 삭제 중 오류 발생", e);
+			throw new RuntimeException("S3 이미지 삭제 실패", e);
 		}
 	}
 }

--- a/src/main/java/com/example/swapit/service/UserWithdrawCompletedEvent.java
+++ b/src/main/java/com/example/swapit/service/UserWithdrawCompletedEvent.java
@@ -1,0 +1,22 @@
+package com.example.swapit.service;
+
+import java.util.List;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.example.swapit.domain.GoodsImages;
+import com.example.swapit.domain.Users;
+
+import lombok.Getter;
+
+@Getter
+public class UserWithdrawCompletedEvent extends ApplicationEvent {
+	private final List<GoodsImages> images;
+	private final Users user;
+
+	public UserWithdrawCompletedEvent(Object source, List<GoodsImages> images, Users user) {
+		super(source);
+		this.images = images;
+		this.user = user;
+	}
+}

--- a/src/test/java/com/example/swapit/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/AuthControllerTest.java
@@ -17,11 +17,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.domain.dto.TokenDTO;
 import com.example.swapit.domain.dto.UserResponseDTO;
+import com.example.swapit.domain.dto.WithdrawDto;
 import com.example.swapit.service.AuthService;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +36,8 @@ public class AuthControllerTest {
 
 	@InjectMocks
 	private AuthController authController;
+
+	ObjectMapper objectMapper = new ObjectMapper();
 
 	@BeforeEach
 	void setUp() {
@@ -240,6 +244,52 @@ public class AuthControllerTest {
 		// When & Then
 		mockMvc.perform(post("/api/user/auth/logout")
 				.header("Authorization", token).contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("구글 탈퇴 신청 성공 테스트")
+	void withdrawGoogleSuccess() throws Exception {
+		// Given
+		String token = "valid_token";
+		String googleToken = "google_access_token";
+
+		WithdrawDto withdrawDto = Mockito.mock(WithdrawDto.class);
+		when(withdrawDto.getReason()).thenReturn("너무 많이 사용해요.");
+
+		doNothing().when(authService).withdrawGoogleUser(googleToken, "너무 많이 사용해요.");
+
+		// When & Then
+		mockMvc.perform(
+				post("/api/user/auth/withdraw/google").header("Authorization", token).header("X-Google-Token", googleToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(withdrawDto)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("카카오 탈퇴 신청 성공 테스트")
+	void withdrawKakaoSuccess() throws Exception {
+		// Given
+		String token = "valid_token";
+		String kakaoToken = "kakao_access_token";
+
+		WithdrawDto withdrawDto = Mockito.mock(WithdrawDto.class);
+		when(withdrawDto.getReason()).thenReturn("너무 많이 사용해요.");
+
+		doNothing().when(authService).withdrawKakaoUser(kakaoToken, "너무 많이 사용해요.");
+
+		// When & Then
+		mockMvc.perform(
+				post("/api/user/auth/withdraw/kakao").header("Authorization", token).header("X-Kakao-Token", kakaoToken)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(withdrawDto)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.example.swapit.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,8 +29,17 @@ import com.example.swapit.domain.Tokens;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.TokenDTO;
 import com.example.swapit.domain.dto.UserResponseDTO;
+import com.example.swapit.repository.ChatRoomsRepository;
+import com.example.swapit.repository.ChatsRepository;
+import com.example.swapit.repository.FcmTokenRepository;
+import com.example.swapit.repository.GoodsImagesRepository;
+import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.NotificationRepository;
+import com.example.swapit.repository.ReviewRepository;
 import com.example.swapit.repository.TokensRepository;
+import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.WithdrawReasonsRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class AuthServiceTest {
@@ -49,6 +59,36 @@ public class AuthServiceTest {
 
 	@Mock
 	private TokensRepository tokensRepository;
+
+	@Mock
+	private CurrentUserService currentUserService;
+
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@Mock
+	private ReviewRepository reviewRepository;
+
+	@Mock
+	private ChatsRepository chatsRepository;
+
+	@Mock
+	private ChatRoomsRepository chatRoomsRepository;
+
+	@Mock
+	private TradesRepository tradesRepository;
+
+	@Mock
+	private GoodsRepository goodsRepository;
+
+	@Mock
+	private GoodsImagesRepository goodsImagesRepository;
+
+	@Mock
+	private WithdrawReasonsRepository withdrawReasonsRepository;
 
 	@Mock
 	private RestTemplate restTemplate;
@@ -494,5 +534,71 @@ public class AuthServiceTest {
 		// Then
 		verify(tokensRepository, times(1)).findByRefreshToken(Token);
 		verify(tokensRepository, never()).delete(any());
+	}
+
+	@Test
+	@DisplayName("회원정보 삭제 성공 테스트")
+	void testUserWithdraw() {
+		Users testUser = Users.builder()
+			.usersId(1L)
+			.nickname("testuser")
+			.email("test@example.com")
+			.profileImageUrl("http://example.com/profile.jpg")
+			.loginInfo("GOOGLE")
+			.role("USER")
+			.isDeleted(false)
+			.build();
+
+		when(currentUserService.getCurrentUser()).thenReturn(testUser);
+
+		// 물건, 채팅방, 거래 관련 리포지토리는 빈 리스트를 반환하도록 설정
+		when(goodsRepository.findByUserOrderByCreatedAtDesc(testUser))
+			.thenReturn(Collections.emptyList());
+		when(goodsImagesRepository.findByGoodIn(Collections.emptyList()))
+			.thenReturn(Collections.emptyList());
+		when(chatRoomsRepository.findMyChatRooms(testUser.getUsersId()))
+			.thenReturn(Collections.emptyList());
+		when(tradesRepository.findAllByUser(testUser.getUsersId()))
+			.thenReturn(Collections.emptyList());
+
+		String reason = "테스트 탈퇴 사유";
+
+		// userWithdraw() 메서드 실행 (내부에서 S3 삭제 메서드도 호출됨)
+		authService.userWithdraw(reason);
+
+		// FCM 토큰, 리프레시 토큰, 알림 삭제 검증
+		verify(fcmTokenRepository).deleteByUser(testUser);
+		verify(tokensRepository).deleteByUser(testUser);
+		verify(notificationRepository).deleteAllByUser(testUser);
+
+		// 후기, 채팅 메시지 삭제 검증
+		verify(reviewRepository).deleteAllByWriterOrReviewee(testUser, testUser);
+		verify(chatsRepository).deleteAllBySender(testUser);
+
+		// 채팅방 관련 삭제 검증
+		verify(chatRoomsRepository).findMyChatRooms(testUser.getUsersId());
+		verify(chatRoomsRepository).deleteAll(anyList());
+
+		// 거래 관련 삭제 검증
+		verify(tradesRepository).findAllByUser(testUser.getUsersId());
+		verify(tradesRepository).deleteAll(anyList());
+
+		// 물건 및 물건 사진 관련 검증
+		verify(goodsRepository).findByUserOrderByCreatedAtDesc(testUser);
+		verify(goodsImagesRepository).findByGoodIn(anyList());
+		verify(goodsImagesRepository).deleteAll(anyList());
+		verify(goodsRepository).deleteAll(anyList());
+
+		// 탈퇴 사유 저장시, userId가 올바르게 전달되었는지 검증
+		verify(withdrawReasonsRepository).save(argThat(wr ->
+			reason.equals(wr.getReason()) &&
+			testUser.getUsersId().equals(wr.getUsersId())
+		));
+
+		// 사용자 삭제 검증
+		verify(usersRepository).delete(testUser);
+
+		// DB 트랜잭션 이후 S3 삭제 수행 검증
+		verify(authService).deleteFilesFromS3AfterTransaction(anyList());
 	}
 }

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -92,6 +93,9 @@ public class AuthServiceTest {
 
 	@Mock
 	private RestTemplate restTemplate;
+
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	@Mock
 	private AwsS3Service awsS3Service;
@@ -599,6 +603,10 @@ public class AuthServiceTest {
 		verify(usersRepository).delete(testUser);
 
 		// DB 트랜잭션 이후 S3 삭제 수행 검증
-		verify(authService).deleteFilesFromS3AfterTransaction(anyList());
+		verify(applicationEventPublisher).publishEvent(argThat(event ->
+			event instanceof UserWithdrawCompletedEvent &&
+			((UserWithdrawCompletedEvent)event).getImages().equals(Collections.emptyList()) &&
+			((UserWithdrawCompletedEvent)event).getUser().equals(testUser)
+		));
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #111 

## 📝 작업 내용

> 구글, 카카오 회원 탈퇴 신청 구현 - 사유 저장/ 물건, 물건 사진, 거래, 채팅방, 채팅메세지, 알림, 후기, fcm 토큰, 리프레시 토큰 삭제
> s3 이미지 다중 삭제
> 토큰 제외 전체 엔티티에 is_deleted 필드 추가 및 soft delete 설정
> 테스트 코드 작성

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> fcm token은 잘 삭제되는지는 확인이 불가했습니다! 해당 부분 제외하고는 잘 실행되는데 제대로 한건지 확신이 없어서 확인 부탁드립니다..!
