### PR TITLE
[fix] 채팅방 정보 조회에 거래 정보 추가

### DIFF
--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
@@ -1,6 +1,6 @@
 package com.example.swapit.domain.dto.chat;
 
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,5 +15,5 @@ public class ChatRoomInfoDto {
 	private String imageUrl;
 	private Long usersId;
 	private String nickname;
-	private TradeInGoodDetailDto trade;
+	private TradeInfoDto trade;
 }

--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatRoomInfoDto.java
@@ -1,5 +1,7 @@
 package com.example.swapit.domain.dto.chat;
 
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,4 +15,5 @@ public class ChatRoomInfoDto {
 	private String imageUrl;
 	private Long usersId;
 	private String nickname;
+	private TradeInGoodDetailDto trade;
 }

--- a/src/main/java/com/example/swapit/domain/dto/good/GoodsDetailDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/GoodsDetailDto.java
@@ -26,11 +26,11 @@ public class GoodsDetailDto {
 	private String placeName;
 	private long viewCount;
 	private List<GoodsImageDto> images;
-	private TradeInGoodDetailDto trade;
+	private TradeInfoDto trade;
 	private LocalDateTime createdAt;
 
 	public static GoodsDetailDto of(Goods good, UserProfileDto userProfileDto, List<GoodsImageDto> images,
-		TradeInGoodDetailDto trade) {
+		TradeInfoDto trade) {
 		return GoodsDetailDto.builder()
 			.goodsId(good.getId())
 			.user(userProfileDto)

--- a/src/main/java/com/example/swapit/domain/dto/good/TradeInfoDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/TradeInfoDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class TradeInGoodDetailDto {
+public class TradeInfoDto {
 	private Long tradesId;
 	private boolean isRequester;
 	private String status;

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -26,6 +26,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
@@ -205,7 +206,8 @@ public class ChatServiceImpl implements ChatService {
 			goods.getPrice(),
 			firstImageUrl,
 			counterpart.getUsersId(),
-			counterpart.getNickname()
+			counterpart.getNickname(),
+			getTrade(chatRooms.getTrade())
 		);
 	}
 
@@ -250,5 +252,13 @@ public class ChatServiceImpl implements ChatService {
 		}
 
 		return counterpart;
+	}
+
+	public TradeInGoodDetailDto getTrade(Trades trade) {
+		Long loggedInUserId = currentUserService.getCurrentUser().getUsersId();
+		boolean isRequester = trade.getRequestedGoods().getUser().getUsersId().equals(loggedInUserId);
+		Long relatedGoodsId = isRequester ? trade.getTargetGoods().getId() : trade.getRequestedGoods().getId();
+		String tradeStatus = trade.getStatus().name();
+		return new TradeInGoodDetailDto(trade.getId(), isRequester, tradeStatus, relatedGoodsId);
 	}
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -26,7 +26,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
@@ -254,11 +254,11 @@ public class ChatServiceImpl implements ChatService {
 		return counterpart;
 	}
 
-	public TradeInGoodDetailDto getTrade(Trades trade) {
+	public TradeInfoDto getTrade(Trades trade) {
 		Long loggedInUserId = currentUserService.getCurrentUser().getUsersId();
 		boolean isRequester = trade.getRequestedGoods().getUser().getUsersId().equals(loggedInUserId);
 		Long relatedGoodsId = isRequester ? trade.getTargetGoods().getId() : trade.getRequestedGoods().getId();
 		String tradeStatus = trade.getStatus().name();
-		return new TradeInGoodDetailDto(trade.getId(), isRequester, tradeStatus, relatedGoodsId);
+		return new TradeInfoDto(trade.getId(), isRequester, tradeStatus, relatedGoodsId);
 	}
 }

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -25,7 +25,7 @@ import com.example.swapit.domain.dto.good.GoodsImageDto;
 import com.example.swapit.domain.dto.good.GoodsListDto;
 import com.example.swapit.domain.dto.good.GoodsRequestDto;
 import com.example.swapit.domain.dto.good.MyGoodDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.GoodsRepository;
@@ -137,7 +137,7 @@ public class GoodsServiceImpl implements GoodsService {
 			.toList();
 
 		// 현재 유저 확인 후, TradeInGoodDetailDto 구성.
-		TradeInGoodDetailDto tradeInGoodDetailDto = currentUserService.getCurrentUserOptional()
+		TradeInfoDto tradeInGoodDetailDto = currentUserService.getCurrentUserOptional()
 			.map(user -> getTradeInDetail(goodsId, user.getUsersId()))
 			.orElse(null);
 
@@ -147,7 +147,7 @@ public class GoodsServiceImpl implements GoodsService {
 	/**
 	 *  현재 사용자가 관련된 거래가 있는지 확인
 	 */
-	private TradeInGoodDetailDto getTradeInDetail(Long goodsId, Long userId) {
+	private TradeInfoDto getTradeInDetail(Long goodsId, Long userId) {
 		Optional<Trades> tradesOpt = tradesRepository.findUserRelatedTrade(goodsId, userId);
 		if (tradesOpt.isEmpty()) {
 			return null;
@@ -161,7 +161,7 @@ public class GoodsServiceImpl implements GoodsService {
 			? trade.getRequestedGoods().getId()
 			: trade.getTargetGoods().getId();
 
-		return new TradeInGoodDetailDto(trade.getId(), isRequester, trade.getStatus().name(), relatedGoodsId);
+		return new TradeInfoDto(trade.getId(), isRequester, trade.getStatus().name(), relatedGoodsId);
 	}
 
 	@Override

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -26,6 +26,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.service.ChatService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -163,8 +164,10 @@ class ChatControllerTest {
 	@DisplayName("채팅방 물건 조회 성공")
 	void getChatRoomGoods() throws Exception {
 		// given
+		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
+
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
-			1L, "아이폰 15", "ELECTRONICS", 2500L, null, 2L, "닉네임");
+			1L, "아이폰 15", "ELECTRONICS", 2500L, null, 2L, "닉네임", trade);
 
 		given(chatService.getChatRoomInfo(any())).willReturn(dto);
 

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -26,7 +26,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.service.ChatService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -164,7 +164,7 @@ class ChatControllerTest {
 	@DisplayName("채팅방 물건 조회 성공")
 	void getChatRoomGoods() throws Exception {
 		// given
-		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
+		TradeInfoDto trade = new TradeInfoDto(1L, true, "PENDING", 2L);
 
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
 			1L, "아이폰 15", "ELECTRONICS", 2500L, null, 2L, "닉네임", trade);

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -1,8 +1,8 @@
 package com.example.swapit.controller;
 
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -34,7 +34,7 @@ import com.example.swapit.domain.dto.good.GoodsImageDto;
 import com.example.swapit.domain.dto.good.GoodsListDto;
 import com.example.swapit.domain.dto.good.GoodsRequestDto;
 import com.example.swapit.domain.dto.good.MyGoodDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.service.GoodsService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -91,7 +91,7 @@ class GoodsControllerTest {
 	@DisplayName("물건 상세 조회 테스트")
 	void getDetailGood() throws Exception {
 		// given
-		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(2L, true, TradeStatus.PENDING.name(), 2L);
+		TradeInfoDto trade = new TradeInfoDto(2L, true, TradeStatus.PENDING.name(), 2L);
 		GoodsDetailDto mockGoodsDetail = new GoodsDetailDto(
 			1L,
 			new UserProfileDto(1L, "testUser", "profileImage", 4.8),

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -28,6 +28,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.service.ChatServiceImpl;
 
 public class ChatControllerDocsTest extends RestDocsTest {
@@ -233,8 +234,10 @@ public class ChatControllerDocsTest extends RestDocsTest {
 	void getChatRoomGoods() throws Exception {
 		// Given
 		Long chatroomId = 1L;
+		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
+
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
-			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", 2L, "닉네임");
+			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", 2L, "닉네임", trade);
 
 		given(chatService.getChatRoomInfo(any())).willReturn(dto);
 
@@ -260,7 +263,13 @@ public class ChatControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.price").type(JsonFieldType.NUMBER).description("물건 예상 가격"),
 						fieldWithPath("results.imageUrl").type(JsonFieldType.STRING).description("물건 이미지 URL"),
 						fieldWithPath("results.usersId").type(JsonFieldType.NUMBER).description("채팅방 상대 ID"),
-						fieldWithPath("results.nickname").type(JsonFieldType.STRING).description("채팅방 상대 닉네임")
+						fieldWithPath("results.nickname").type(JsonFieldType.STRING).description("채팅방 상대 닉네임"),
+						fieldWithPath("results.trade").type(JsonFieldType.OBJECT).description("스왑 정보"),
+						fieldWithPath("results.trade.tradesId").type(JsonFieldType.NUMBER).description("스왑 ID"),
+						fieldWithPath("results.trade.isRequester").type(JsonFieldType.BOOLEAN).description("스왑 요청자 여부"),
+						fieldWithPath("results.trade.status").type(JsonFieldType.STRING).description("스왑 상태"),
+						fieldWithPath("results.trade.relatedGoodsId").type(JsonFieldType.NUMBER)
+							.description("연관된 물건 ID")
 					)
 					.responseSchema(Schema.schema("ChatRoomInfoDto"))
 					.build()

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -28,7 +28,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.service.ChatServiceImpl;
 
 public class ChatControllerDocsTest extends RestDocsTest {
@@ -234,7 +234,7 @@ public class ChatControllerDocsTest extends RestDocsTest {
 	void getChatRoomGoods() throws Exception {
 		// Given
 		Long chatroomId = 1L;
-		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
+		TradeInfoDto trade = new TradeInfoDto(1L, true, "PENDING", 2L);
 
 		ChatRoomInfoDto dto = new ChatRoomInfoDto(
 			1L, "아이폰 15", "ELECTRONICS", 1000000L, "http://example.com/image.jpg", 2L, "닉네임", trade);

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -35,7 +35,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
-import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
+import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
@@ -348,7 +348,7 @@ class ChatServiceTest {
 			.trade(trades)
 			.build();
 
-		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
+		TradeInfoDto trade = new TradeInfoDto(1L, true, "PENDING", 2L);
 
 		when(chatRoomsRepository.findById(chatroomId))
 			.thenReturn(Optional.of(chatRooms));

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -23,6 +24,7 @@ import com.example.swapit.domain.Chats;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.GoodsQuality;
+import com.example.swapit.domain.TradeStatus;
 import com.example.swapit.domain.Trades;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.chat.ChatDto;
@@ -33,6 +35,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
+import com.example.swapit.domain.dto.good.TradeInGoodDetailDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
@@ -69,6 +72,7 @@ class ChatServiceTest {
 	private NotificationEventPublisher notificationEventPublisher;
 
 	@InjectMocks
+	@Spy
 	private ChatServiceImpl chatService;
 
 	private final String testCdnUrl = "http://example.com/";
@@ -326,10 +330,25 @@ class ChatServiceTest {
 			.user(currentUser)
 			.build();
 
+		Goods targetGoods = Goods.builder()
+			.title("Test Targeg Good")
+			.user(counterpart)
+			.build();
+
+		Trades trades = Trades.builder()
+			.id(1L)
+			.requestedGoods(goods)
+			.targetGoods(targetGoods)
+			.status(TradeStatus.PENDING)
+			.build();
+
 		ChatRooms chatRooms = ChatRooms.builder()
 			.id(chatroomId)
 			.goods(goods)
+			.trade(trades)
 			.build();
+
+		TradeInGoodDetailDto trade = new TradeInGoodDetailDto(1L, true, "PENDING", 2L);
 
 		when(chatRoomsRepository.findById(chatroomId))
 			.thenReturn(Optional.of(chatRooms));
@@ -343,6 +362,7 @@ class ChatServiceTest {
 
 		when(currentUserService.getCurrentUser()).thenReturn(currentUser);
 		when(chatService.getCounterpart(chatRooms)).thenReturn(counterpart);
+		when(chatService.getTrade(chatRooms.getTrade())).thenReturn(trade);
 
 		// when
 		ChatRoomInfoDto result = chatService.getChatRoomInfo(chatroomId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #116 

## 📝 작업 내용

> dto 이름 변경, 채팅방 정보 조회 api에 거래 정보 응답 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 💬 리뷰 요구사항(선택)

> 변경한 dto 명칭 괜찮은지 의견 부탁드립니다!
