### PR TITLE
[fix] 알림에서 deeplink 대신 relatedData로 변경해서 응답, 테이블 수정

### DIFF
--- a/src/main/java/com/example/swapit/domain/NotificationEvent.java
+++ b/src/main/java/com/example/swapit/domain/NotificationEvent.java
@@ -8,20 +8,13 @@ import lombok.Getter;
 public class NotificationEvent extends ApplicationEvent {
 	private final Long userId;
 	private final NotificationType type;
-	private final String deeplink;
+	private final Long relatedData;
 
-	public NotificationEvent(Object source, Long userId, NotificationType type) {
+	public NotificationEvent(Object source, Long userId, NotificationType type, Long relatedData) {
 		super(source);
 		this.userId = userId;
 		this.type = type;
-		this.deeplink = type.getDeeplink();
-	}
-
-	public NotificationEvent(Object source, Long userId, NotificationType type, Object... urlParams) {
-		super(source);
-		this.userId = userId;
-		this.type = type;
-		this.deeplink = type.getDeeplink(urlParams);
+		this.relatedData = relatedData;
 	}
 
 	public Notifications toEntity(Users user) {
@@ -30,7 +23,7 @@ public class NotificationEvent extends ApplicationEvent {
 			.type(type)
 			.title(type.getTitle())
 			.body(type.getBody())
-			.deeplink(deeplink)
+			.relatedData(relatedData)
 			.isRead(false)
 			.build();
 	}

--- a/src/main/java/com/example/swapit/domain/NotificationType.java
+++ b/src/main/java/com/example/swapit/domain/NotificationType.java
@@ -7,18 +7,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum NotificationType {
-	REQUESTED("새로운 스왑 요청 도착", "새로운 스왑 요청이 도착했습니다! 확인해보세요.", "myapp://swap/requests/%s"),
-	ACCEPTED("스왑 요청 수락", "스왑 요청이 수락되었습니다! 거래를 진행해보세요.", "myapp://goods/%s"),
-	REJECTED("스왑 요청 거절", "스왑 요청이 거절되었습니다. 다른 거래를 찾아보세요.", "myapp://goods/%s"),
-	COMPLETED("스왑 완료", "스왑이 성공적으로 완료되었습니다 🎉! 리뷰를 작성해주세요.", "myapp://swap/my-goods"),
-	REVIEW("리뷰 도착", "새로운 리뷰가 작성되었습니다! 확인해보세요.", "myapp://user/profile"),
-	CHAT("새로운 채팅 메세지 도착", "새로운 채팅 메세지가 도착했습니다! 지금 확인하세요.", "myapp://chatroom/%s");
+	REQUESTED("새로운 스왑 요청 도착", "새로운 스왑 요청이 도착했습니다! 확인해보세요."),
+	ACCEPTED("스왑 요청 수락", "스왑 요청이 수락되었습니다! 거래를 진행해보세요."),
+	REJECTED("스왑 요청 거절", "스왑 요청이 거절되었습니다. 다른 거래를 찾아보세요."),
+	COMPLETED("스왑 완료", "스왑이 성공적으로 완료되었습니다 🎉! 리뷰를 작성해주세요."),
+	REVIEW("리뷰 도착", "새로운 리뷰가 작성되었습니다! 확인해보세요."),
+	CHAT("새로운 채팅 메세지 도착", "새로운 채팅 메세지가 도착했습니다! 지금 확인하세요.");
 
 	private final String title;
 	private final String body;
-	private final String deeplink;
-
-	public String getDeeplink(Object... params) {
-		return params.length > 0 ? String.format(this.deeplink, params) : this.deeplink;
-	}
 }

--- a/src/main/java/com/example/swapit/domain/Notifications.java
+++ b/src/main/java/com/example/swapit/domain/Notifications.java
@@ -48,8 +48,7 @@ public class Notifications extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "VARCHAR(255)")
 	private String body;
 
-	@Column(nullable = false)
-	private String deeplink;
+	private Long relatedData;
 
 	@Builder.Default
 	@Setter

--- a/src/main/java/com/example/swapit/domain/dto/NotificationDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/NotificationDto.java
@@ -17,14 +17,14 @@ public class NotificationDto {
 	private final String type;
 	private final String title;
 	private final String body;
-	private final String deeplink;
+	private final Long relatedData;
 	private final LocalDateTime createdAt;
 
 	public static NotificationDto of(Notifications noti) {
 		return NotificationDto.builder()
 			.notificationsId(noti.getId())
 			.type(noti.getType().toString())
-			.deeplink(noti.getDeeplink())
+			.relatedData(noti.getRelatedData())
 			.title(noti.getTitle())
 			.body(noti.getBody())
 			.createdAt(noti.getCreatedAt())

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -102,7 +102,7 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생 (거래요청)
 		notificationEventPublisher.publishNotification(
-			targetGoods.getUser().getUsersId(), NotificationType.REQUESTED, targetGoods.getId());
+			targetGoods.getUser().getUsersId(), NotificationType.REQUESTED, requestedGoods.getId());
 
 		// 채팅방이 존재하면 거래 연결 + 메시지 전송
 		Optional<ChatRooms> chatRoomsOpt = chatRoomsRepository.findByGoodsAndInviter(targetGoods,
@@ -236,7 +236,7 @@ public class TradesServiceImpl implements TradesService {
 		Users recipient = (userId.equals(trade.getTargetGoods().getUser().getUsersId()))
 			? trade.getRequestedGoods().getUser() : trade.getTargetGoods().getUser();
 		notificationEventPublisher.publishNotification(
-			recipient.getUsersId(), NotificationType.COMPLETED
+			recipient.getUsersId(), NotificationType.COMPLETED, null
 		);
 	}
 

--- a/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.swapit.service.notification;
 
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +32,13 @@ public class FcmCustomNotificationServiceImpl implements FcmNotificationService 
 		Map<String, String> data = new HashMap<>();
 		data.put("notificationsId", noti.getId().toString());
 		data.put("type", noti.getType().toString());
-		data.put("deeplink", noti.getDeeplink());
+		data.put("title", noti.getTitle());
+		data.put("body", noti.getBody());
+		data.put("relatedData", noti.getRelatedData().toString());
+
+		// createdAt은 formatter로 문자형식으로 바꿔서 보냄.
+		DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+		data.put("createdAt", noti.getCreatedAt().format(formatter));
 
 		Message message = Message.builder()
 			.setToken(fcmToken)

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventPublisher.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventPublisher.java
@@ -14,13 +14,7 @@ public class NotificationEventPublisher {
 
 	private final ApplicationEventPublisher eventPublisher;
 
-	// 기본 URL 사용
-	public void publishNotification(Long userId, NotificationType type) {
-		eventPublisher.publishEvent(new NotificationEvent(this, userId, type));
-	}
-
-	// URL에 동적 값 적용
-	public void publishNotification(Long userId, NotificationType type, Object... urlParams) {
-		eventPublisher.publishEvent(new NotificationEvent(this, userId, type, urlParams));
+	public void publishNotification(Long userId, NotificationType type, Long relatedData) {
+		eventPublisher.publishEvent(new NotificationEvent(this, userId, type, relatedData));
 	}
 }

--- a/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
@@ -43,8 +43,8 @@ class NotificationControllerTest {
 	void getMyNotificationsTest() throws Exception {
 		// Given
 		List<NotificationDto> notifications = List.of(
-			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", "deeplink1", LocalDateTime.now()),
-			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", "deeplink2", LocalDateTime.now())
+			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", 1L, LocalDateTime.now()),
+			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", 2L, LocalDateTime.now())
 		);
 		NotificationListDto notificationListDto = new NotificationListDto(notifications);
 		ApiResponse<NotificationListDto> mockResponse = ApiResponse.success(notificationListDto);
@@ -60,7 +60,7 @@ class NotificationControllerTest {
 			.andExpect(jsonPath("$.results.notifications[0].type").value("CHAT"))
 			.andExpect(jsonPath("$.results.notifications[0].title").value("Title 1"))
 			.andExpect(jsonPath("$.results.notifications[0].body").value("Body 1"))
-			.andExpect(jsonPath("$.results.notifications[0].deeplink").value("deeplink1"));
+			.andExpect(jsonPath("$.results.notifications[0].relatedData").value(1));
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
@@ -40,8 +40,8 @@ public class NotificationControllerDocsTest extends RestDocsTest {
 	void getMyNotificationsTest() throws Exception {
 		// Given
 		List<NotificationDto> notifications = List.of(
-			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", "deeplink1", LocalDateTime.now()),
-			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", "deeplink2", LocalDateTime.now())
+			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", 1L, LocalDateTime.now()),
+			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", 2L, LocalDateTime.now())
 		);
 		NotificationListDto notificationListDto = new NotificationListDto(notifications);
 
@@ -68,8 +68,8 @@ public class NotificationControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.notifications[].type").type(JsonFieldType.STRING).description("알림 타입"),
 						fieldWithPath("results.notifications[].title").type(JsonFieldType.STRING).description("알림 제목"),
 						fieldWithPath("results.notifications[].body").type(JsonFieldType.STRING).description("알림 내용"),
-						fieldWithPath("results.notifications[].deeplink").type(JsonFieldType.STRING)
-							.description("알림 클릭 시 이동 URL (app deeplink)"),
+						fieldWithPath("results.notifications[].relatedData").type(JsonFieldType.NUMBER)
+							.description("연관된 데이터 ID (Long)"),
 						fieldWithPath("results.notifications[].createdAt").type(JsonFieldType.STRING)
 							.description("알림 생성 시간")
 					)

--- a/src/test/java/com/example/swapit/service/notification/FcmNotificationServiceTest.java
+++ b/src/test/java/com/example/swapit/service/notification/FcmNotificationServiceTest.java
@@ -3,6 +3,8 @@ package com.example.swapit.service.notification;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.Notifications;
@@ -36,7 +39,8 @@ class FcmNotificationServiceTest {
 
 		Users user = Users.builder().build();
 		Notifications noti = new Notifications(1L, user, NotificationType.REQUESTED, "Test Title", "Test Body",
-			"deeplink", false);
+			1L, false);
+		ReflectionTestUtils.setField(noti, "createdAt", LocalDateTime.now());
 
 		// FirebaseMessaging을 Mock으로 생성 (mockStatic() 사용)
 		try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {

--- a/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
@@ -59,9 +59,9 @@ class NotificationEventListenerTest {
 			.type(NotificationType.CHAT)
 			.title(NotificationType.CHAT.getTitle())
 			.body(NotificationType.CHAT.getBody())
-			.deeplink(NotificationType.CHAT.getDeeplink())
+			.relatedData(2L)
 			.build();
-		testEvent = new NotificationEvent(1L, testUser.getUsersId(), NotificationType.CHAT);
+		testEvent = new NotificationEvent(1L, testUser.getUsersId(), NotificationType.CHAT, 2L);
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/service/notification/NotificationEventPublisherTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationEventPublisherTest.java
@@ -29,35 +29,15 @@ class NotificationEventPublisherTest {
 	}
 
 	@Test
-	@DisplayName("알림발생(기본 url) - 성공")
+	@DisplayName("알림발생 성공")
 	void testPublishNotification_WithBasicUrl() {
 		// given
 		Long userId = 1L;
 		NotificationType type = NotificationType.REQUESTED;
+		Long relatedData = 2L;
 
 		// when
-		notificationEventPublisher.publishNotification(userId, type);
-
-		// then
-		ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);
-		verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-
-		NotificationEvent event = eventCaptor.getValue();
-		assertThat(event).isNotNull();
-		assertThat(event.getUserId()).isEqualTo(userId);
-		assertThat(event.getType()).isEqualTo(type);
-	}
-
-	@Test
-	@DisplayName("알림발생(동적 url) - 성공")
-	void testPublishNotification_WithDynamicUrl() {
-		// given
-		Long userId = 2L;
-		NotificationType type = NotificationType.ACCEPTED;
-		Object[] urlParams = {"param1", "param2"};
-
-		// when
-		notificationEventPublisher.publishNotification(userId, type, urlParams);
+		notificationEventPublisher.publishNotification(userId, type, relatedData);
 
 		// then
 		ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);

--- a/src/test/java/com/example/swapit/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationServiceTest.java
@@ -57,7 +57,7 @@ class NotificationServiceTest {
 			.user(mockUser)
 			.title("title")
 			.body("Test Notification")
-			.deeplink("/test-url")
+			.relatedData(1L)
 			.isRead(false)
 			.type(NotificationType.REQUESTED)
 			.build();
@@ -87,7 +87,7 @@ class NotificationServiceTest {
 			.user(mockUser)
 			.title("title")
 			.body("Test Notification")
-			.deeplink("/test-url")
+			.relatedData(1L)
 			.isRead(false)
 			.build();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #123 

## 📝 작업 내용
- 알림테이블에 deeplink 대신 relatedData로 필드 변경
- 응답 dto도 relatedData로 변경
- 관련된 service에서 무조건 Object...param으로 받았던 걸 relatedData로 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- Notifications 엔티티의 deeplink 필드 삭제, relatedData (Long) 필드 추가

## 💬 리뷰 요구사항(선택)
없습니다!
