### PR TITLE
[feat] 알림 수신 설정 조회 api 구현

### DIFF
--- a/src/main/java/com/example/swapit/controller/NotificationController.java
+++ b/src/main/java/com/example/swapit/controller/NotificationController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
 import com.example.swapit.service.notification.NotificationService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,11 @@ public class NotificationController {
 	@GetMapping
 	public ApiResponse<NotificationListDto> getMyNotifications() {
 		return ApiResponse.success(notificationService.getMyNotifications());
+	}
+
+	@GetMapping("/settings")
+	public ApiResponse<NotificationSettingDto> getMyNotificationSetting() {
+		return ApiResponse.success(notificationService.getMyNotificationSetting());
 	}
 
 	@PatchMapping("/{notificationsId}/read")

--- a/src/main/java/com/example/swapit/domain/NotificationEvent.java
+++ b/src/main/java/com/example/swapit/domain/NotificationEvent.java
@@ -8,20 +8,13 @@ import lombok.Getter;
 public class NotificationEvent extends ApplicationEvent {
 	private final Long userId;
 	private final NotificationType type;
-	private final String deeplink;
+	private final Long relatedData;
 
-	public NotificationEvent(Object source, Long userId, NotificationType type) {
+	public NotificationEvent(Object source, Long userId, NotificationType type, Long relatedData) {
 		super(source);
 		this.userId = userId;
 		this.type = type;
-		this.deeplink = type.getDeeplink();
-	}
-
-	public NotificationEvent(Object source, Long userId, NotificationType type, Object... urlParams) {
-		super(source);
-		this.userId = userId;
-		this.type = type;
-		this.deeplink = type.getDeeplink(urlParams);
+		this.relatedData = relatedData;
 	}
 
 	public Notifications toEntity(Users user) {
@@ -30,7 +23,7 @@ public class NotificationEvent extends ApplicationEvent {
 			.type(type)
 			.title(type.getTitle())
 			.body(type.getBody())
-			.deeplink(deeplink)
+			.relatedData(relatedData)
 			.isRead(false)
 			.build();
 	}

--- a/src/main/java/com/example/swapit/domain/NotificationType.java
+++ b/src/main/java/com/example/swapit/domain/NotificationType.java
@@ -7,18 +7,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum NotificationType {
-	REQUESTED("새로운 스왑 요청 도착", "새로운 스왑 요청이 도착했습니다! 확인해보세요.", "myapp://swap/requests/%s"),
-	ACCEPTED("스왑 요청 수락", "스왑 요청이 수락되었습니다! 거래를 진행해보세요.", "myapp://goods/%s"),
-	REJECTED("스왑 요청 거절", "스왑 요청이 거절되었습니다. 다른 거래를 찾아보세요.", "myapp://goods/%s"),
-	COMPLETED("스왑 완료", "스왑이 성공적으로 완료되었습니다 🎉! 리뷰를 작성해주세요.", "myapp://swap/my-goods"),
-	REVIEW("리뷰 도착", "새로운 리뷰가 작성되었습니다! 확인해보세요.", "myapp://user/profile"),
-	CHAT("새로운 채팅 메세지 도착", "새로운 채팅 메세지가 도착했습니다! 지금 확인하세요.", "myapp://chatroom/%s");
+	REQUESTED("새로운 스왑 요청 도착", "새로운 스왑 요청이 도착했습니다! 확인해보세요."),
+	ACCEPTED("스왑 요청 수락", "스왑 요청이 수락되었습니다! 거래를 진행해보세요."),
+	REJECTED("스왑 요청 거절", "스왑 요청이 거절되었습니다. 다른 거래를 찾아보세요."),
+	COMPLETED("스왑 완료", "스왑이 성공적으로 완료되었습니다 🎉! 리뷰를 작성해주세요."),
+	REVIEW("리뷰 도착", "새로운 리뷰가 작성되었습니다! 확인해보세요."),
+	CHAT("새로운 채팅 메세지 도착", "새로운 채팅 메세지가 도착했습니다! 지금 확인하세요.");
 
 	private final String title;
 	private final String body;
-	private final String deeplink;
-
-	public String getDeeplink(Object... params) {
-		return params.length > 0 ? String.format(this.deeplink, params) : this.deeplink;
-	}
 }

--- a/src/main/java/com/example/swapit/domain/Notifications.java
+++ b/src/main/java/com/example/swapit/domain/Notifications.java
@@ -48,8 +48,7 @@ public class Notifications extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "VARCHAR(255)")
 	private String body;
 
-	@Column(nullable = false)
-	private String deeplink;
+	private Long relatedData;
 
 	@Builder.Default
 	@Setter

--- a/src/main/java/com/example/swapit/domain/Users.java
+++ b/src/main/java/com/example/swapit/domain/Users.java
@@ -52,6 +52,10 @@ public class Users extends BaseEntity {
 	private String role;
 
 	@Builder.Default
+	@Column(nullable = false)
+	private boolean notificationEnabled = true;
+
+	@Builder.Default
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Goods> goodsList = new ArrayList<>();
 

--- a/src/main/java/com/example/swapit/domain/dto/NotificationDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/NotificationDto.java
@@ -17,14 +17,14 @@ public class NotificationDto {
 	private final String type;
 	private final String title;
 	private final String body;
-	private final String deeplink;
+	private final Long relatedData;
 	private final LocalDateTime createdAt;
 
 	public static NotificationDto of(Notifications noti) {
 		return NotificationDto.builder()
 			.notificationsId(noti.getId())
 			.type(noti.getType().toString())
-			.deeplink(noti.getDeeplink())
+			.relatedData(noti.getRelatedData())
 			.title(noti.getTitle())
 			.body(noti.getBody())
 			.createdAt(noti.getCreatedAt())

--- a/src/main/java/com/example/swapit/domain/dto/NotificationSettingDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/NotificationSettingDto.java
@@ -1,0 +1,4 @@
+package com.example.swapit.domain.dto;
+
+public record NotificationSettingDto(boolean notificationEnabled) {
+}

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -102,7 +102,7 @@ public class TradesServiceImpl implements TradesService {
 
 		// 알림 발생 (거래요청)
 		notificationEventPublisher.publishNotification(
-			targetGoods.getUser().getUsersId(), NotificationType.REQUESTED, targetGoods.getId());
+			targetGoods.getUser().getUsersId(), NotificationType.REQUESTED, requestedGoods.getId());
 
 		// 채팅방이 존재하면 거래 연결 + 메시지 전송
 		Optional<ChatRooms> chatRoomsOpt = chatRoomsRepository.findByGoodsAndInviter(targetGoods,
@@ -236,7 +236,7 @@ public class TradesServiceImpl implements TradesService {
 		Users recipient = (userId.equals(trade.getTargetGoods().getUser().getUsersId()))
 			? trade.getRequestedGoods().getUser() : trade.getTargetGoods().getUser();
 		notificationEventPublisher.publishNotification(
-			recipient.getUsersId(), NotificationType.COMPLETED
+			recipient.getUsersId(), NotificationType.COMPLETED, null
 		);
 	}
 

--- a/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.swapit.service.notification;
 
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +32,13 @@ public class FcmCustomNotificationServiceImpl implements FcmNotificationService 
 		Map<String, String> data = new HashMap<>();
 		data.put("notificationsId", noti.getId().toString());
 		data.put("type", noti.getType().toString());
-		data.put("deeplink", noti.getDeeplink());
+		data.put("title", noti.getTitle());
+		data.put("body", noti.getBody());
+		data.put("relatedData", noti.getRelatedData().toString());
+
+		// createdAt은 formatter로 문자형식으로 바꿔서 보냄.
+		DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+		data.put("createdAt", noti.getCreatedAt().format(formatter));
 
 		Message message = Message.builder()
 			.setToken(fcmToken)

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
@@ -1,14 +1,11 @@
 package com.example.swapit.service.notification;
 
-import java.util.Optional;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
-import com.example.swapit.domain.FcmToken;
 import com.example.swapit.domain.NotificationEvent;
 import com.example.swapit.domain.Notifications;
 import com.example.swapit.domain.Users;
@@ -42,25 +39,27 @@ public class NotificationEventListener {
 		Notifications noti = event.toEntity(user);
 		notificationRepository.save(noti);
 
-		// 웹소켓 알림 전송 (앱이 온라인 상태) : "/user/queue/notifications" 구독
-		boolean isWebsocketSent = false;
-		try {
-			messagingTemplate.convertAndSendToUser(userId.toString(), "/queue/notifications",
-				NotificationDto.of(noti));
-			isWebsocketSent = true;
-		} catch (Exception e) {
-			// todo : 이상 없으면 이후에 로그 제거
-			log.info("[WS알림LOG] 알림 웹소켓 전송 실패 -> FCM으로 전송. {}", e.getMessage());
+		// 알림 설정이 꺼져 있으면 전송 생략
+		if (!user.isNotificationEnabled()) {
+			log.info("[알림 꺼짐] 사용자 ID {}: 알림 전송하지 않음 {}", userId, noti.getId());
+			return;
 		}
 
-		// 앱이 백그라운드 상태일 때, FCM 알림 전송 (웹소켓 실패 or FCM 알림 필요)
-		if (!isWebsocketSent) {
-			Optional<FcmToken> optionalFcmToken = fcmTokenRepository.findByUser(user);
-			if (optionalFcmToken.isPresent()) {
-				fcmNotificationService.sendFcmNotification(optionalFcmToken.get().getFcmToken(), noti);
-			} else {
-				log.warn("[FCM알림 실패] 사용자 ID {} 에 대한 FCM 토큰이 존재하지 않음.", userId);
-			}
+		// 웹소켓 알림 전송 (앱이 온라인 상태) : "/user/queue/notifications" 구독된 상태
+		try {
+			messagingTemplate.convertAndSendToUser(
+				userId.toString(), "/queue/notifications", NotificationDto.of(noti)
+			);
+		} catch (Exception e) {
+			log.info("[WS알림LOG] 알림 웹소켓 전송 실패 -> FCM으로 전송. {}", e.getMessage());
+			sendFcm(user, noti);
 		}
+	}
+
+	private void sendFcm(Users user, Notifications noti) {
+		fcmTokenRepository.findByUser(user).ifPresentOrElse(
+			token -> fcmNotificationService.sendFcmNotification(token.getFcmToken(), noti),
+			() -> log.warn("[FCM알림 실패] 사용자 ID {}: FCM 토큰 없음", user.getUsersId())
+		);
 	}
 }

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventPublisher.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventPublisher.java
@@ -14,13 +14,7 @@ public class NotificationEventPublisher {
 
 	private final ApplicationEventPublisher eventPublisher;
 
-	// 기본 URL 사용
-	public void publishNotification(Long userId, NotificationType type) {
-		eventPublisher.publishEvent(new NotificationEvent(this, userId, type));
-	}
-
-	// URL에 동적 값 적용
-	public void publishNotification(Long userId, NotificationType type, Object... urlParams) {
-		eventPublisher.publishEvent(new NotificationEvent(this, userId, type, urlParams));
+	public void publishNotification(Long userId, NotificationType type, Long relatedData) {
+		eventPublisher.publishEvent(new NotificationEvent(this, userId, type, relatedData));
 	}
 }

--- a/src/main/java/com/example/swapit/service/notification/NotificationService.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationService.java
@@ -1,9 +1,12 @@
 package com.example.swapit.service.notification;
 
 import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
 
 public interface NotificationService {
 	NotificationListDto getMyNotifications();
+
+	NotificationSettingDto getMyNotificationSetting();
 
 	void notificationRead(Long notificationId);
 }

--- a/src/main/java/com/example/swapit/service/notification/NotificationServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.swapit.domain.Notifications;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.NotificationDto;
 import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
 import com.example.swapit.repository.NotificationRepository;
 import com.example.swapit.service.CurrentUserService;
 
@@ -30,6 +31,12 @@ public class NotificationServiceImpl implements NotificationService {
 				.stream()
 				.map(NotificationDto::of)
 				.toList());
+	}
+
+	@Override
+	public NotificationSettingDto getMyNotificationSetting() {
+		Users user = currentUserService.getCurrentUser();
+		return new NotificationSettingDto(user.isNotificationEnabled());
 	}
 
 	@Override

--- a/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
@@ -43,8 +43,8 @@ class NotificationControllerTest {
 	void getMyNotificationsTest() throws Exception {
 		// Given
 		List<NotificationDto> notifications = List.of(
-			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", "deeplink1", LocalDateTime.now()),
-			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", "deeplink2", LocalDateTime.now())
+			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", 1L, LocalDateTime.now()),
+			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", 2L, LocalDateTime.now())
 		);
 		NotificationListDto notificationListDto = new NotificationListDto(notifications);
 		ApiResponse<NotificationListDto> mockResponse = ApiResponse.success(notificationListDto);
@@ -60,7 +60,7 @@ class NotificationControllerTest {
 			.andExpect(jsonPath("$.results.notifications[0].type").value("CHAT"))
 			.andExpect(jsonPath("$.results.notifications[0].title").value("Title 1"))
 			.andExpect(jsonPath("$.results.notifications[0].body").value("Body 1"))
-			.andExpect(jsonPath("$.results.notifications[0].deeplink").value("deeplink1"));
+			.andExpect(jsonPath("$.results.notifications[0].relatedData").value(1));
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/NotificationControllerTest.java
@@ -13,13 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.example.swapit.common.api.ApiResponse;
 import com.example.swapit.domain.dto.NotificationDto;
 import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
 import com.example.swapit.service.notification.NotificationService;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +64,21 @@ class NotificationControllerTest {
 			.andExpect(jsonPath("$.results.notifications[0].title").value("Title 1"))
 			.andExpect(jsonPath("$.results.notifications[0].body").value("Body 1"))
 			.andExpect(jsonPath("$.results.notifications[0].relatedData").value(1));
+	}
+
+	@Test
+	@DisplayName("알림 수신 설정 조회 API 테스트")
+	void getMyNotificationSetting() throws Exception {
+		// given
+		NotificationSettingDto dto = new NotificationSettingDto(true);
+		Mockito.when(notificationService.getMyNotificationSetting()).thenReturn(dto);
+
+		// when & then
+		mvc.perform(get("/api/user/notifications/settings")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.results.notificationEnabled").value(true));
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
@@ -40,8 +40,8 @@ public class NotificationControllerDocsTest extends RestDocsTest {
 	void getMyNotificationsTest() throws Exception {
 		// Given
 		List<NotificationDto> notifications = List.of(
-			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", "deeplink1", LocalDateTime.now()),
-			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", "deeplink2", LocalDateTime.now())
+			new NotificationDto(1L, "CHAT", "Title 1", "Body 1", 1L, LocalDateTime.now()),
+			new NotificationDto(2L, "REQUESTED", "Title 2", "Body 2", 2L, LocalDateTime.now())
 		);
 		NotificationListDto notificationListDto = new NotificationListDto(notifications);
 
@@ -68,8 +68,8 @@ public class NotificationControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.notifications[].type").type(JsonFieldType.STRING).description("알림 타입"),
 						fieldWithPath("results.notifications[].title").type(JsonFieldType.STRING).description("알림 제목"),
 						fieldWithPath("results.notifications[].body").type(JsonFieldType.STRING).description("알림 내용"),
-						fieldWithPath("results.notifications[].deeplink").type(JsonFieldType.STRING)
-							.description("알림 클릭 시 이동 URL (app deeplink)"),
+						fieldWithPath("results.notifications[].relatedData").type(JsonFieldType.NUMBER)
+							.description("연관된 데이터 ID (Long)"),
 						fieldWithPath("results.notifications[].createdAt").type(JsonFieldType.STRING)
 							.description("알림 생성 시간")
 					)

--- a/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/NotificationControllerDocsTest.java
@@ -23,6 +23,7 @@ import com.epages.restdocs.apispec.Schema;
 import com.example.swapit.controller.NotificationController;
 import com.example.swapit.domain.dto.NotificationDto;
 import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
 import com.example.swapit.service.notification.NotificationService;
 
 public class NotificationControllerDocsTest extends RestDocsTest {
@@ -74,6 +75,40 @@ public class NotificationControllerDocsTest extends RestDocsTest {
 							.description("알림 생성 시간")
 					)
 					.responseSchema(Schema.schema("NotificationListDto"))
+					.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("알림 설정 조회 API 문서화")
+	void getMyNotificationSettingTest() throws Exception {
+		// Given
+		when(notificationService.getMyNotificationSetting())
+			.thenReturn(new NotificationSettingDto(true));
+
+		// When & Then
+		mockMvc.perform(get("/api/user/notifications/settings")
+				.header("Authorization", "Bearer valid_token")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+			.andExpect(jsonPath("$.results.notificationEnabled").value(true))
+			.andDo(document("get-notification-setting",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				resource(ResourceSnippetParameters.builder()
+					.tag("Notification")
+					.description("사용자의 알림 설정 여부를 조회하는 API")
+					.responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+						fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+						fieldWithPath("results").type(JsonFieldType.OBJECT).description("응답 결과 데이터"),
+						fieldWithPath("results.notificationEnabled").type(JsonFieldType.BOOLEAN)
+							.description("알림 수신 설정 여부 (true: 켜짐)")
+					)
+					.responseSchema(Schema.schema("NotificationSettingDto"))
 					.build()
 				)
 			));

--- a/src/test/java/com/example/swapit/service/notification/FcmNotificationServiceTest.java
+++ b/src/test/java/com/example/swapit/service/notification/FcmNotificationServiceTest.java
@@ -3,6 +3,8 @@ package com.example.swapit.service.notification;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.Notifications;
@@ -36,7 +39,8 @@ class FcmNotificationServiceTest {
 
 		Users user = Users.builder().build();
 		Notifications noti = new Notifications(1L, user, NotificationType.REQUESTED, "Test Title", "Test Body",
-			"deeplink", false);
+			1L, false);
+		ReflectionTestUtils.setField(noti, "createdAt", LocalDateTime.now());
 
 		// FirebaseMessaging을 Mock으로 생성 (mockStatic() 사용)
 		try (MockedStatic<FirebaseMessaging> mockedStatic = mockStatic(FirebaseMessaging.class)) {

--- a/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
@@ -59,9 +59,9 @@ class NotificationEventListenerTest {
 			.type(NotificationType.CHAT)
 			.title(NotificationType.CHAT.getTitle())
 			.body(NotificationType.CHAT.getBody())
-			.deeplink(NotificationType.CHAT.getDeeplink())
+			.relatedData(2L)
 			.build();
-		testEvent = new NotificationEvent(1L, testUser.getUsersId(), NotificationType.CHAT);
+		testEvent = new NotificationEvent(1L, testUser.getUsersId(), NotificationType.CHAT, 2L);
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/service/notification/NotificationEventPublisherTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationEventPublisherTest.java
@@ -29,35 +29,15 @@ class NotificationEventPublisherTest {
 	}
 
 	@Test
-	@DisplayName("알림발생(기본 url) - 성공")
+	@DisplayName("알림발생 성공")
 	void testPublishNotification_WithBasicUrl() {
 		// given
 		Long userId = 1L;
 		NotificationType type = NotificationType.REQUESTED;
+		Long relatedData = 2L;
 
 		// when
-		notificationEventPublisher.publishNotification(userId, type);
-
-		// then
-		ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);
-		verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-
-		NotificationEvent event = eventCaptor.getValue();
-		assertThat(event).isNotNull();
-		assertThat(event.getUserId()).isEqualTo(userId);
-		assertThat(event.getType()).isEqualTo(type);
-	}
-
-	@Test
-	@DisplayName("알림발생(동적 url) - 성공")
-	void testPublishNotification_WithDynamicUrl() {
-		// given
-		Long userId = 2L;
-		NotificationType type = NotificationType.ACCEPTED;
-		Object[] urlParams = {"param1", "param2"};
-
-		// when
-		notificationEventPublisher.publishNotification(userId, type, urlParams);
+		notificationEventPublisher.publishNotification(userId, type, relatedData);
 
 		// then
 		ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);

--- a/src/test/java/com/example/swapit/service/notification/NotificationServiceImplTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.example.swapit.service.notification;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.domain.NotificationType;
+import com.example.swapit.domain.Notifications;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dto.NotificationDto;
+import com.example.swapit.domain.dto.NotificationListDto;
+import com.example.swapit.domain.dto.NotificationSettingDto;
+import com.example.swapit.repository.NotificationRepository;
+import com.example.swapit.service.CurrentUserService;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+	@InjectMocks
+	private NotificationServiceImpl notificationService;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@Mock
+	private CurrentUserService currentUserService;
+
+	@Test
+	@DisplayName("알림 조회")
+	void getMyNotifications() {
+		// given
+		Users mockUser = new Users();
+		Notifications notification = Notifications.builder()
+			.id(1L)
+			.isRead(false)
+			.type(NotificationType.REQUESTED)
+			.build();
+		List<Notifications> notifications = List.of(notification);
+
+		Mockito.when(currentUserService.getCurrentUser()).thenReturn(mockUser);
+		Mockito.when(notificationRepository.findByUserAndReadNotOrderByCreatedAtDesc(mockUser))
+			.thenReturn(notifications);
+
+		// when
+		NotificationListDto result = notificationService.getMyNotifications();
+
+		// then
+		assertThat(result.getNotifications()).hasSize(1);
+		assertThat(result.getNotifications().get(0)).isInstanceOf(NotificationDto.class);
+	}
+
+	@Test
+	@DisplayName("알림 수신 설정 조회 성공")
+	void getMyNotificationSetting() {
+		// given
+		Users user = new Users();
+		ReflectionTestUtils.setField(user, "notificationEnabled", true);
+
+		Mockito.when(currentUserService.getCurrentUser()).thenReturn(user);
+
+		// when
+		NotificationSettingDto result = notificationService.getMyNotificationSetting();
+
+		// then
+		assertThat(result.notificationEnabled()).isTrue();
+	}
+
+	@Test
+	@DisplayName("알림 읽음 성공")
+	void notificationRead() {
+		// given
+		Long notiId = 1L;
+		Notifications notification = Notifications.builder().id(notiId).isRead(false).build();
+
+		Mockito.when(notificationRepository.findById(notiId)).thenReturn(Optional.of(notification));
+
+		// when
+		notificationService.notificationRead(notiId);
+
+		// then
+		assertThat(notification.isRead()).isTrue();
+		Mockito.verify(notificationRepository).save(notification);
+	}
+
+	@Test
+	@DisplayName("알림읽음 실패 - 알림 없음")
+	void notificationRead_fail() {
+		// given
+		Long notiId = 999L;
+		Mockito.when(notificationRepository.findById(notiId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> notificationService.notificationRead(notiId))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
+	}
+}

--- a/src/test/java/com/example/swapit/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationServiceTest.java
@@ -57,7 +57,7 @@ class NotificationServiceTest {
 			.user(mockUser)
 			.title("title")
 			.body("Test Notification")
-			.deeplink("/test-url")
+			.relatedData(1L)
 			.isRead(false)
 			.type(NotificationType.REQUESTED)
 			.build();
@@ -87,7 +87,7 @@ class NotificationServiceTest {
 			.user(mockUser)
 			.title("title")
 			.body("Test Notification")
-			.deeplink("/test-url")
+			.relatedData(1L)
 			.isRead(false)
 			.build();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #122 

## 📝 작업 내용
- 알림 수신 설정 api 구현
- 관련 테스트 코드 작성

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- Users 엔티티에 notificationEnabled(boolean) 필드 추가

## 💬 리뷰 요구사항(선택)
앞의 pr 이후 구현 부분이랑 겹쳐서 브랜치만 분리해서 올려서, commit 분리를 못했습니다..!!