### PR TITLE
[fix] trade 유니크 제약 조건 제거 + 제약 검증을 repository로 이동

### DIFF
--- a/src/main/java/com/example/swapit/domain/Trades.java
+++ b/src/main/java/com/example/swapit/domain/Trades.java
@@ -10,10 +10,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +28,9 @@ import lombok.Setter;
 @SQLDelete(sql = "UPDATE trades SET is_deleted = true WHERE trades_id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "trades",
-	uniqueConstraints = @UniqueConstraint(columnNames = {"target_goods_id, requested_goods_id"})
+	indexes = {
+		@Index(name = "idx_target_requested_deleted", columnList = "requested_goods_id, target_goods_id, is_deleted")
+	}
 )
 public class Trades extends BaseEntity {
 

--- a/src/main/java/com/example/swapit/domain/dao/ConflictTradeResult.java
+++ b/src/main/java/com/example/swapit/domain/dao/ConflictTradeResult.java
@@ -1,0 +1,16 @@
+package com.example.swapit.domain.dao;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public record ConflictTradeResult(Long tradesId, ConflictType type) {
+	@Getter
+	@AllArgsConstructor
+	public enum ConflictType {
+		TRADE_ALREADY_REQUESTED_IN_REVERSE("상대방이 이미 역방향으로 거래 요청한 상태입니다."),
+		TRADE_ALREADY_EXISTS_WITH_SAME_GOODS("동일한 거래 조합이 이미 존재합니다."),
+		TRADE_ALREADY_REJECTED("이전에 동일한 거래 요청이 거절된 이력이 있습니다."),
+		TRADE_REQUESTED_BY_SAME_USER("이미 해당 사용자가 다른 물건으로 거래 요청했습니다.");
+		private final String description;
+	}
+}

--- a/src/main/java/com/example/swapit/repository/good/CustomGoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/good/CustomGoodsRepository.java
@@ -1,4 +1,4 @@
-package com.example.swapit.repository;
+package com.example.swapit.repository.good;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/swapit/repository/good/CustomGoodsRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/good/CustomGoodsRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.example.swapit.repository;
+package com.example.swapit.repository.good;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/swapit/repository/good/GoodsRepository.java
+++ b/src/main/java/com/example/swapit/repository/good/GoodsRepository.java
@@ -1,4 +1,4 @@
-package com.example.swapit.repository;
+package com.example.swapit.repository.good;
 
 import java.util.List;
 

--- a/src/main/java/com/example/swapit/repository/trade/TradeQueryRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradeQueryRepository.java
@@ -1,0 +1,11 @@
+package com.example.swapit.repository.trade;
+
+import java.util.Optional;
+
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dao.ConflictTradeResult;
+
+public interface TradeQueryRepository {
+	Optional<ConflictTradeResult> findConflictTrade(Goods requested, Goods target, Users requester);
+}

--- a/src/main/java/com/example/swapit/repository/trade/TradeQueryRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradeQueryRepositoryImpl.java
@@ -9,7 +9,7 @@ import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dao.ConflictTradeResult;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class TradeQueryRepositoryImpl implements TradeQueryRepository {
 		QTrades t = QTrades.trades;
 
 		// 조건 별로 case 분기 : select 포함되는 표현 식.
-		NumberTemplate<Integer> conflictType = (NumberTemplate<Integer>)new CaseBuilder()
+		NumberExpression<Integer> conflictType = new CaseBuilder()
 			.when(t.requestedGoods.eq(target)
 				.and(t.targetGoods.eq(requested))
 				.and(t.status.ne(TradeStatus.REJECTED))
@@ -35,6 +35,7 @@ public class TradeQueryRepositoryImpl implements TradeQueryRepository {
 
 			.when(t.requestedGoods.eq(requested)
 				.and(t.targetGoods.eq(target))
+				.and(t.status.ne(TradeStatus.REJECTED))
 				.and(t.isDeleted.isFalse()))
 			.then(1) // TRADE_ALREADY_EXISTS_WITH_SAME_GOODS
 
@@ -58,17 +59,17 @@ public class TradeQueryRepositoryImpl implements TradeQueryRepository {
 			.from(t)
 			.where(
 				t.isDeleted.isFalse().and(
-					// 1. 역방향 거래 요청
+					// 0. 역방향 거래 요청
 					t.requestedGoods.eq(target).and(t.targetGoods.eq(requested)).and(t.status.ne(TradeStatus.REJECTED))
-						// 2. 동일한 거래 조합이 이미 존재
+						// 1. 동일한 거래 조합이 이미 존재
 						.or(t.requestedGoods.eq(requested)
 							.and(t.targetGoods.eq(target))
 							.and(t.status.ne(TradeStatus.REJECTED)))
-						// 3. 동일한 거래가 과거에 거절된 적 있음
+						// 2. 동일한 거래가 과거에 거절된 적 있음
 						.or(t.requestedGoods.eq(requested)
 							.and(t.targetGoods.eq(target))
 							.and(t.status.eq(TradeStatus.REJECTED)))
-						// 4. 동일 사용자가 이미 다른 물건으로 요청한 상태
+						// 3. 동일 사용자가 이미 다른 물건으로 요청한 상태
 						.or(t.targetGoods.eq(target)
 							.and(t.requestedGoods.user.eq(requester))
 							.and(t.status.ne(TradeStatus.REJECTED)))

--- a/src/main/java/com/example/swapit/repository/trade/TradeQueryRepositoryImpl.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradeQueryRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.example.swapit.repository.trade;
+
+import java.util.Optional;
+
+import com.example.swapit.domain.Goods;
+import com.example.swapit.domain.QTrades;
+import com.example.swapit.domain.TradeStatus;
+import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dao.ConflictTradeResult;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TradeQueryRepositoryImpl implements TradeQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Optional<ConflictTradeResult> findConflictTrade(Goods requested, Goods target, Users requester) {
+		QTrades t = QTrades.trades;
+
+		// 조건 별로 case 분기 : select 포함되는 표현 식.
+		NumberTemplate<Integer> conflictType = (NumberTemplate<Integer>)new CaseBuilder()
+			.when(t.requestedGoods.eq(target)
+				.and(t.targetGoods.eq(requested))
+				.and(t.status.ne(TradeStatus.REJECTED))
+				.and(t.isDeleted.isFalse()))
+			.then(0) // TRADE_ALREADY_REQUESTED_IN_REVERSE
+
+			.when(t.requestedGoods.eq(requested)
+				.and(t.targetGoods.eq(target))
+				.and(t.isDeleted.isFalse()))
+			.then(1) // TRADE_ALREADY_EXISTS_WITH_SAME_GOODS
+
+			.when(t.requestedGoods.eq(requested)
+				.and(t.targetGoods.eq(target))
+				.and(t.status.eq(TradeStatus.REJECTED))
+				.and(t.isDeleted.isFalse()))
+			.then(2) // TRADE_ALREADY_REJECTED
+
+			.when(t.targetGoods.eq(target)
+				.and(t.requestedGoods.user.eq(requester))
+				.and(t.status.ne(TradeStatus.REJECTED))
+				.and(t.isDeleted.isFalse()))
+			.then(3) // TRADE_REQUESTED_BY_SAME_USER
+
+			.otherwise(-1);
+
+		// 조회 쿼리
+		Tuple result = queryFactory
+			.select(t.id, conflictType)
+			.from(t)
+			.where(
+				t.isDeleted.isFalse().and(
+					// 1. 역방향 거래 요청
+					t.requestedGoods.eq(target).and(t.targetGoods.eq(requested)).and(t.status.ne(TradeStatus.REJECTED))
+						// 2. 동일한 거래 조합이 이미 존재
+						.or(t.requestedGoods.eq(requested)
+							.and(t.targetGoods.eq(target))
+							.and(t.status.ne(TradeStatus.REJECTED)))
+						// 3. 동일한 거래가 과거에 거절된 적 있음
+						.or(t.requestedGoods.eq(requested)
+							.and(t.targetGoods.eq(target))
+							.and(t.status.eq(TradeStatus.REJECTED)))
+						// 4. 동일 사용자가 이미 다른 물건으로 요청한 상태
+						.or(t.targetGoods.eq(target)
+							.and(t.requestedGoods.user.eq(requester))
+							.and(t.status.ne(TradeStatus.REJECTED)))
+				)
+			)
+			.limit(1)
+			.fetchOne();
+
+		if (result == null)
+			return Optional.empty();
+
+		Long tradeId = result.get(t.id);
+		Integer typeIndex = result.get(conflictType);
+
+		// conflictType 인덱스를 ConflictTradeResult enum으로 매핑
+		ConflictTradeResult.ConflictType type = switch (typeIndex) {
+			case 0 -> ConflictTradeResult.ConflictType.TRADE_ALREADY_REQUESTED_IN_REVERSE;
+			case 1 -> ConflictTradeResult.ConflictType.TRADE_ALREADY_EXISTS_WITH_SAME_GOODS;
+			case 2 -> ConflictTradeResult.ConflictType.TRADE_ALREADY_REJECTED;
+			case 3 -> ConflictTradeResult.ConflictType.TRADE_REQUESTED_BY_SAME_USER;
+			default -> {
+				log.error("[거래 생성 오류 (매핑된 enum) 타입 없음] : tradeId {}", tradeId);
+				throw new IllegalStateException("거래 생성 오류 (매핑된 enum) 타입 없음: " + typeIndex);
+			}
+		};
+
+		return Optional.of(new ConflictTradeResult(tradeId, type));
+	}
+}

--- a/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
@@ -17,7 +17,7 @@ import com.example.swapit.domain.dto.trade.TradeCountProjection;
 
 import io.lettuce.core.dynamic.annotation.Param;
 
-public interface TradesRepository extends JpaRepository<Trades, Long> {
+public interface TradesRepository extends JpaRepository<Trades, Long>, TradeQueryRepository {
 	long countByTargetGoodsIdAndStatus(Long goodsId, TradeStatus status);
 
 	@Modifying

--- a/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
@@ -1,4 +1,4 @@
-package com.example.swapit.repository;
+package com.example.swapit.repository.trade;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,23 +25,23 @@ public interface TradesRepository extends JpaRepository<Trades, Long> {
 	void rejectOtherTrades(@Param("targetGoods") Goods targetGoods, @Param("acceptedTradeId") Long acceptedTradeId);
 
 	@Query("SELECT t.targetGoods.id AS goodsId, COALESCE(COUNT(t), 0) AS tradeCount "
-		   + "FROM Trades t "
-		   + "WHERE t.targetGoods.id IN :goodsIds AND t.status <> 'REJECTED' "
-		   + "GROUP BY t.targetGoods.id")
+		+ "FROM Trades t "
+		+ "WHERE t.targetGoods.id IN :goodsIds AND t.status <> 'REJECTED' "
+		+ "GROUP BY t.targetGoods.id")
 	List<TradeCountProjection> findTradeCountByGoodsIds(@Param("goodsIds") List<Long> goodsIds);
 
 	@Query("SELECT new com.example.swapit.domain.dao.TradeGoodsDao(t.targetGoods, t.requestedGoods, t.id) "
-		   + "FROM Trades t "
-		   + "WHERE t.requestedGoods.user.usersId = :userId AND t.status <> 'REJECTED'")
+		+ "FROM Trades t "
+		+ "WHERE t.requestedGoods.user.usersId = :userId AND t.status <> 'REJECTED'")
 	List<TradeGoodsDao> findMyRequests(@Param("userId") Long userId);
 
 	@Query("SELECT t.requestedGoods FROM Trades t WHERE t.targetGoods.id = :goodsId AND t.status <> 'REJECTED' ORDER BY t.createdAt DESC")
 	List<Goods> findGoodsRequests(@Param("goodsId") Long goodsId);
 
 	@Query("SELECT new com.example.swapit.domain.dto.trade.InProgressCountDto(t.targetGoods.id, COUNT(t)) "
-		   + "FROM Trades t "
-		   + "WHERE t.targetGoods.id IN :goodsIds AND t.status = 'INPROGRESS' "
-		   + "GROUP BY t.targetGoods.id")
+		+ "FROM Trades t "
+		+ "WHERE t.targetGoods.id IN :goodsIds AND t.status = 'INPROGRESS' "
+		+ "GROUP BY t.targetGoods.id")
 	List<InProgressCountDto> findInProgressCountByGoodsIds(@Param("goodsIds") List<Long> goodsIds);
 
 	@Query("SELECT t.id FROM Trades t WHERE t.requestedGoods = :requested AND t.targetGoods = :target AND t.status <> :status")

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -28,13 +28,13 @@ import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.FcmTokenRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.NotificationRepository;
 import com.example.swapit.repository.ReviewRepository;
 import com.example.swapit.repository.TokensRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
 import com.example.swapit.repository.WithdrawReasonsRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -30,9 +30,9 @@ import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/GoodsServiceImpl.java
@@ -28,9 +28,9 @@ import com.example.swapit.domain.dto.good.MyGoodDto;
 import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
-import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ReviewServiceImpl.java
@@ -16,7 +16,7 @@ import com.example.swapit.domain.dto.ReviewDto;
 import com.example.swapit.domain.dto.ReviewListDto;
 import com.example.swapit.domain.dto.ReviewRequestDto;
 import com.example.swapit.repository.ReviewRepository;
-import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -5,9 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +19,7 @@ import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.TradeStatus;
 import com.example.swapit.domain.Trades;
 import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dao.ConflictTradeResult;
 import com.example.swapit.domain.dao.TradeGoodsDao;
 import com.example.swapit.domain.dto.Result;
 import com.example.swapit.domain.dto.trade.InProgressCountDto;
@@ -32,8 +31,8 @@ import com.example.swapit.domain.dto.trade.TradeMyGoodsRequestDto;
 import com.example.swapit.domain.dto.trade.TradesRequestDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
-import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -65,26 +64,16 @@ public class TradesServiceImpl implements TradesService {
 		Goods targetGoods = goodsRepository.findById(tradesRequestDto.getTargetGoodsId())
 			.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
 
-		// requestedGoods <-> targetGoods가 바뀌어서 요청된 건은 없는지 검증
-		Optional<Long> failRequestTrade = tradesRepository.findIdByRequestedGoodsAndTargetGoodsAndStatusNot(targetGoods,
-			requestedGoods, TradeStatus.REJECTED);
-		if (failRequestTrade.isPresent()) {
-			log.debug("[{}] : trade id={}", ErrorCode.TRADE_ALREADY_REQUESTED.getMessage(), failRequestTrade.get());
-			return Result.fail(ErrorCode.TRADE_ALREADY_REQUESTED.getMessage());
-		}
+		// 거래 충돌 여부 검사
+		Optional<ConflictTradeResult> conflictOpt = tradesRepository.findConflictTrade(requestedGoods, targetGoods,
+			requestedGoods.getUser());
 
-		// 동일 사용자가 targetGoods에 요청한 내역이 있는지 검사
-		failRequestTrade = tradesRepository.findIdByTargetGoodsAndRequestedGoodsUserAndStatusNot(targetGoods,
-			requestedGoods.getUser(), TradeStatus.REJECTED);
-		if (failRequestTrade.isPresent()) {
-			log.debug("[{}] : trade id={}", ErrorCode.DUPLICATE_TRADE_REQUEST.getMessage(), failRequestTrade.get());
-			return Result.fail(ErrorCode.DUPLICATE_TRADE_REQUEST.getMessage());
-		}
+		if (conflictOpt.isPresent()) {
+			ConflictTradeResult conflict = conflictOpt.get();
+			log.warn("[swap 요청 실패: {}] 원인: tradeId={}, requestedGoodsId={}, targetGoodsId={}", conflict.type(),
+				conflict.tradesId(), requestedGoods.getId(), targetGoods.getId());
 
-		// 동일한 물건으로 reject 되었는데, 또 같은 요청을 할 경우 오류 발생.
-		if (tradesRepository.existsByRequestedGoodsAndTargetGoodsAndStatus(requestedGoods, targetGoods,
-			TradeStatus.REJECTED)) {
-			return Result.fail(ErrorCode.TRADE_ALREADY_REJECTED_WITH_SAME_GOODS.getMessage());
+			return Result.fail(conflict.type().getDescription());
 		}
 
 		// 최대 PENDING 요청 제한 체크
@@ -95,10 +84,7 @@ public class TradesServiceImpl implements TradesService {
 		}
 
 		// 거래 생성
-		Trades savedTrades = createAndSaveTrade(requestedGoods, targetGoods);
-		if (savedTrades == null) {
-			return Result.fail(ErrorCode.DUPLICATE_TRADE_REQUEST.getMessage());
-		}
+		Trades savedTrades = tradesRepository.save(new Trades(requestedGoods, targetGoods));
 
 		// 알림 발생 (거래요청)
 		notificationEventPublisher.publishNotification(
@@ -112,16 +98,6 @@ public class TradesServiceImpl implements TradesService {
 		);
 
 		return Result.success(savedTrades.getId());
-	}
-
-	private Trades createAndSaveTrade(Goods requestedGoods, Goods targetGoods) {
-		try {
-			return tradesRepository.save(new Trades(requestedGoods, targetGoods));
-		} catch (DataIntegrityViolationException | ConstraintViolationException e) {
-			log.warn("[swap 요청] Duplicate trade request: requestedGoodsId={}, targetGoodsId={}, errorName={}",
-				requestedGoods.getId(), targetGoods.getId(), e.getClass().getSimpleName());
-			return null;
-		}
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/UsersServiceImpl.java
@@ -18,9 +18,9 @@ import com.example.swapit.domain.dto.ReviewDto;
 import com.example.swapit.domain.dto.UserNicknameDto;
 import com.example.swapit.domain.dto.UserPageDto;
 import com.example.swapit.repository.FcmTokenRepository;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.good.GoodsRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/test/java/com/example/swapit/repository/GoodsRepositoryTest.java
+++ b/src/test/java/com/example/swapit/repository/GoodsRepositoryTest.java
@@ -25,6 +25,7 @@ import com.example.swapit.domain.Categories;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.GoodsQuality;
 import com.example.swapit.domain.Users;
+import com.example.swapit.repository.good.GoodsRepository;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;

--- a/src/test/java/com/example/swapit/repository/TradesRepositoryTest.java
+++ b/src/test/java/com/example/swapit/repository/TradesRepositoryTest.java
@@ -1,9 +1,12 @@
 package com.example.swapit.repository;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,9 @@ import com.example.swapit.domain.GoodsQuality;
 import com.example.swapit.domain.TradeStatus;
 import com.example.swapit.domain.Trades;
 import com.example.swapit.domain.Users;
+import com.example.swapit.domain.dao.ConflictTradeResult;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 
 import jakarta.persistence.EntityManager;
 
@@ -63,18 +69,137 @@ class TradesRepositoryTest {
 	@Autowired
 	private EntityManager em;
 
-	@Test
-	@DisplayName("거래 거절 - 특정 거래를 제외한 나머지 거래들이 REJECTED로 변경되는지 확인")
-	void rejectOtherTrades() {
-		// Given
-		// 거래 생성을 위한 users, goods
-		Users requester = Users.builder()
+	Users requester, owner;
+	Categories category;
+	Goods requestGood, targetGood;
+
+	@BeforeEach
+	void setUp() {
+		requester = Users.builder()
 			.nickname("requester")
 			.profileImageUrl("requester")
 			.email("requester")
 			.loginInfo("google")
 			.role("ROLE_USER")
 			.build();
+		owner = Users.builder()
+			.nickname("owner")
+			.profileImageUrl("owner")
+			.email("owner")
+			.loginInfo("google")
+			.role("ROLE_USER")
+			.build();
+		usersRepository.saveAll(List.of(requester, owner));
+
+		category = categoriesRepository.save(
+			Categories.builder().name("MISC").build());
+
+		requestGood = Goods.builder()
+			.user(requester)
+			.title("requestGood")
+			.price(1000)
+			.quality(GoodsQuality.GOOD)
+			.category(category)
+			.content("requestGood")
+			.placeName("place")
+			.build();
+		targetGood = Goods.builder()
+			.user(owner)
+			.title("targetGood")
+			.price(1000)
+			.quality(GoodsQuality.GOOD)
+			.category(category)
+			.content("targetGood")
+			.placeName("place")
+			.build();
+		goodsRepository.saveAll(List.of(requestGood, targetGood));
+	}
+
+	@Test
+	@DisplayName("거래 요청 - 제약 걸리지 않음.")
+	void createTrade_noConflict() {
+		// given
+		// when
+		Optional<ConflictTradeResult> result = tradesRepository.findConflictTrade(requestGood, targetGood, requester);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 역방향 요청이 있는 경우")
+	void createTrade_conflict0() {
+		// given
+		tradesRepository.save(new Trades(targetGood, requestGood)); // 이미 반대로 거래가 있음.
+
+		// when
+		Optional<ConflictTradeResult> result = tradesRepository.findConflictTrade(requestGood, targetGood, requester);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().type()).isEqualTo(ConflictTradeResult.ConflictType.TRADE_ALREADY_REQUESTED_IN_REVERSE);
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 같은 거래 조합으로 거래가 이미 존재하는 경우")
+	void createTrade_conflict1() {
+		// given
+		tradesRepository.save(new Trades(requestGood, targetGood));
+
+		// when
+		Optional<ConflictTradeResult> result = tradesRepository.findConflictTrade(requestGood, targetGood, requester);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().type()).isEqualTo(
+			ConflictTradeResult.ConflictType.TRADE_ALREADY_EXISTS_WITH_SAME_GOODS);
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 동일한 거래가 과거게 거절된 적이 있는 경우")
+	void createTrade_conflict2() {
+		// given
+		Trades trade = new Trades(requestGood, targetGood);
+		trade.setStatus(TradeStatus.REJECTED);
+		tradesRepository.save(trade);
+
+		// when
+		Optional<ConflictTradeResult> result = tradesRepository.findConflictTrade(requestGood, targetGood, requester);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().type()).isEqualTo(ConflictTradeResult.ConflictType.TRADE_ALREADY_REJECTED);
+	}
+
+	@Test
+	@DisplayName("거래 요청 실패 - 동일 사용자가 이미 다른 거래로 요청한 경우")
+	void createTrade_conflict3() {
+		// given
+		Goods anotherGood = goodsRepository.save(
+			Goods.builder()
+				.user(requester)
+				.title("requestGood2")
+				.price(10000)
+				.quality(GoodsQuality.EXCELLENT)
+				.category(category)
+				.content("requestGood2")
+				.placeName("place")
+				.build());
+		tradesRepository.save(new Trades(anotherGood, targetGood));
+
+		// when
+		Optional<ConflictTradeResult> result = tradesRepository.findConflictTrade(requestGood, targetGood, requester);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().type()).isEqualTo(ConflictTradeResult.ConflictType.TRADE_REQUESTED_BY_SAME_USER);
+	}
+
+	@Test
+	@DisplayName("거래 거절 - 특정 거래를 제외한 나머지 거래들이 REJECTED로 변경되는지 확인")
+	void rejectOtherTrades() {
+		// Given
+		// 거래 생성을 위한 users, goods
 		Users requester2 = Users.builder()
 			.nickname("requester2")
 			.profileImageUrl("requester2")
@@ -89,27 +214,8 @@ class TradesRepositoryTest {
 			.loginInfo("google")
 			.role("ROLE_USER")
 			.build();
-		Users owner = Users.builder()
-			.nickname("owner")
-			.profileImageUrl("owner")
-			.email("owner")
-			.loginInfo("google")
-			.role("ROLE_USER")
-			.build();
-		usersRepository.saveAll(List.of(requester, requester2, requester3, owner));
+		usersRepository.saveAll(List.of(requester2, requester3));
 
-		Categories category = categoriesRepository.save(
-			Categories.builder().name("MISC").build());
-
-		Goods requestGood = Goods.builder()
-			.user(requester)
-			.title("requestGood")
-			.price(1000)
-			.quality(GoodsQuality.GOOD)
-			.category(category)
-			.content("requestGood")
-			.placeName("place")
-			.build();
 		Goods requestGood2 = Goods.builder()
 			.user(requester2)
 			.title("requestGood2")
@@ -126,15 +232,6 @@ class TradesRepositoryTest {
 			.quality(GoodsQuality.GOOD)
 			.category(category)
 			.content("requestGood3")
-			.placeName("place")
-			.build();
-		Goods targetGood = Goods.builder()
-			.user(owner)
-			.title("targetGood")
-			.price(1000)
-			.quality(GoodsQuality.GOOD)
-			.category(category)
-			.content("targetGood")
 			.placeName("place")
 			.build();
 		goodsRepository.saveAll(List.of(requestGood, requestGood2, requestGood3, targetGood));

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -34,13 +34,13 @@ import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.FcmTokenRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.NotificationRepository;
 import com.example.swapit.repository.ReviewRepository;
 import com.example.swapit.repository.TokensRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
 import com.example.swapit.repository.WithdrawReasonsRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class AuthServiceTest {

--- a/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AwsS3ServiceTest.java
@@ -20,7 +20,7 @@ import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.Users;
-import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.good.GoodsRepository;
 
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -39,9 +39,9 @@ import com.example.swapit.domain.dto.good.TradeInfoDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.ChatsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/example/swapit/service/GoodServiceTest.java
+++ b/src/test/java/com/example/swapit/service/GoodServiceTest.java
@@ -22,8 +22,8 @@ import com.example.swapit.domain.dto.good.GoodsDetailDto;
 import com.example.swapit.domain.dto.good.GoodsRequestDto;
 import com.example.swapit.repository.CategoriesRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
+import com.example.swapit.repository.good.GoodsRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GoodServiceTest {

--- a/src/test/java/com/example/swapit/service/GoodsImagesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/GoodsImagesServiceTest.java
@@ -26,7 +26,7 @@ import com.example.swapit.domain.GoodsImages;
 import com.example.swapit.domain.GoodsQuality;
 import com.example.swapit.domain.Users;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
+import com.example.swapit.repository.good.GoodsRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GoodsImagesServiceTest {

--- a/src/test/java/com/example/swapit/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ReviewServiceTest.java
@@ -25,7 +25,7 @@ import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.ReviewListDto;
 import com.example.swapit.domain.dto.ReviewRequestDto;
 import com.example.swapit.repository.ReviewRepository;
-import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.example.swapit.common.exception.CustomException;
@@ -39,8 +38,8 @@ import com.example.swapit.domain.dto.trade.TradeMyGoodsRequestDto;
 import com.example.swapit.domain.dto.trade.TradesRequestDto;
 import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
-import com.example.swapit.repository.GoodsRepository;
-import com.example.swapit.repository.TradesRepository;
+import com.example.swapit.repository.good.GoodsRepository;
+import com.example.swapit.repository.trade.TradesRepository;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
@@ -164,117 +163,6 @@ public class TradesServiceTest {
 		verify(goodsRepository, times(1)).findById(dto.getTargetGoodsId());
 		verify(tradesRepository, times(1)).countByTargetGoodsIdAndStatus(dto.getTargetGoodsId(), TradeStatus.PENDING);
 		verify(tradesRepository, never()).save(any(Trades.class));
-	}
-
-	@Test
-	@DisplayName("거래 요청 실패 - 중복 거래 요청")
-	void requestTradesDuplicateFailure() {
-		// Given
-		Users requester = Users.builder()
-			.email("email")
-			.build();
-		Goods requestedGoods = Goods.builder()
-			.user(requester)
-			.build();
-
-		Users target = Users.builder()
-			.email("email")
-			.build();
-		Goods targetGoods = Goods.builder()
-			.user(target)
-			.build();
-
-		dto = new TradesRequestDto(1L, 2L);
-
-		when(goodsRepository.findById(dto.getRequestedGoodsId())).thenReturn(Optional.of(requestedGoods));
-		when(goodsRepository.findById(dto.getTargetGoodsId())).thenReturn(Optional.of(targetGoods));
-		when(tradesRepository.countByTargetGoodsIdAndStatus(dto.getTargetGoodsId(), TradeStatus.PENDING)).thenReturn(
-			5L);
-		doThrow(new DataIntegrityViolationException("Duplicate")).when(tradesRepository).save(any(Trades.class));
-
-		// When
-		Result<Long> result = tradesService.requestTrade(dto);
-
-		// Then
-		assertFalse(result.isSuccess());
-		assertEquals(ErrorCode.DUPLICATE_TRADE_REQUEST.getMessage(), result.getMessage());
-		verify(goodsRepository, times(1)).findById(dto.getRequestedGoodsId());
-		verify(goodsRepository, times(1)).findById(dto.getTargetGoodsId());
-		verify(tradesRepository, times(1)).countByTargetGoodsIdAndStatus(dto.getTargetGoodsId(), TradeStatus.PENDING);
-		verify(tradesRepository, times(1)).save(any(Trades.class));
-	}
-
-	@Test
-	@DisplayName("거래 요청 실패 - requestedGoods <-> targetGoods 반대로 이미 있을 때 요청 실패")
-	void requestTrade_ShouldThrowException_WhenTradeAlreadyRequested() {
-		// given
-		Users requester = Users.builder()
-			.email("email")
-			.build();
-		Goods requestedGoods = Goods.builder()
-			.user(requester)
-			.build();
-
-		Users target = Users.builder()
-			.email("email")
-			.build();
-		Goods targetGoods = Goods.builder()
-			.user(target)
-			.build();
-
-		Long requestedGoodsId = 1L;
-		Long targetGoodsId = 2L;
-
-		TradesRequestDto tradesRequestDto = new TradesRequestDto(requestedGoodsId, targetGoodsId);
-
-		when(goodsRepository.findById(requestedGoodsId)).thenReturn(Optional.of(requestedGoods));
-		when(goodsRepository.findById(targetGoodsId)).thenReturn(Optional.of(targetGoods));
-		// 이미 동일한 거래가 존재 (status != REJECTED)
-		when(tradesRepository.findIdByRequestedGoodsAndTargetGoodsAndStatusNot(targetGoods, requestedGoods,
-			TradeStatus.REJECTED)).thenReturn(Optional.of(999L)); // 이미 존재하는 거래 ID
-
-		// when
-		Result<Long> result = tradesService.requestTrade(tradesRequestDto);
-
-		// when & then
-		assertFalse(result.isSuccess());
-		assertEquals(ErrorCode.TRADE_ALREADY_REQUESTED.getMessage(), result.getMessage());
-	}
-
-	@Test
-	@DisplayName("동일한 물건으로 reject 되었는데, 또 같은 요청을 할 경우 오류 발생")
-	void requestTrade_ShouldThrowException_WhenTradeAlreadyRejected() {
-		// given
-		Users requester = Users.builder()
-			.email("email")
-			.build();
-		Goods requestedGoods = Goods.builder()
-			.user(requester)
-			.build();
-
-		Users target = Users.builder()
-			.email("email")
-			.build();
-		Goods targetGoods = Goods.builder()
-			.user(target)
-			.build();
-
-		Long requestedGoodsId = 1L;
-		Long targetGoodsId = 2L;
-		TradesRequestDto tradesRequestDto = new TradesRequestDto(requestedGoodsId, targetGoodsId);
-		
-		when(goodsRepository.findById(requestedGoodsId)).thenReturn(Optional.of(requestedGoods));
-		when(goodsRepository.findById(targetGoodsId)).thenReturn(Optional.of(targetGoods));
-		when(tradesRepository.existsByRequestedGoodsAndTargetGoodsAndStatus(
-			requestedGoods, targetGoods, TradeStatus.REJECTED
-		)).thenReturn(true);
-
-		// when
-		Result<Long> result = tradesService.requestTrade(tradesRequestDto);
-
-		// then
-		assertFalse(result.isSuccess());
-		assertEquals(ErrorCode.TRADE_ALREADY_REJECTED_WITH_SAME_GOODS.getMessage(), result.getMessage());
 	}
 
 	@Test

--- a/src/test/java/com/example/swapit/service/UsersServiceTest.java
+++ b/src/test/java/com/example/swapit/service/UsersServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.swapit.domain.GoodsTradeStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,12 +17,12 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.domain.GoodsTradeStatus;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.UserPageDto;
-import com.example.swapit.repository.GoodsRepository;
 import com.example.swapit.repository.ReviewRepository;
-import com.example.swapit.repository.TradesRepository;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.repository.good.GoodsRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UsersServiceTest {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #128 

## 📝 작업 내용
- Trades 의 유니크 제약 조건 삭제 후, 인덱스 추가
- trades를 생성하기 전에 검증하는 걸, service -> repository 레이어로 변경.
  - service에서 검증하려니, 조회 쿼리가 4번이상 조회됨.
  - 따라서 repository에서 1번만 조회되도록 변경
- test 코드도 repositoryTest로 이동
- good, trade 패키지 분리

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- Trades에 유니크 제약조건 삭제
- 인덱스 추가

## 💬 리뷰 요구사항(선택)
없습니다!

