### PR TITLE
[fix] 물건 상세 조회에서 연결된 swap이 rejected 되지 않은 것만 조회 하는 것으로 변경

### DIFF
--- a/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
@@ -52,7 +52,8 @@ public interface TradesRepository extends JpaRepository<Trades, Long>, TradeQuer
 
 	@Query("""
 		SELECT t FROM Trades t
-		WHERE (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId)
+		WHERE t.isDeleted = false AND t.status <> 'REJECTED'
+		AND (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId)
 		OR (t.requestedGoods.id = :goodsId AND t.targetGoods.user.usersId = :userId)
 		ORDER BY t.updatedAt DESC""")
 	Optional<Trades> findUserRelatedTrade(@Param("goodsId") Long goodsId, @Param("userId") Long userId);

--- a/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
@@ -53,8 +53,8 @@ public interface TradesRepository extends JpaRepository<Trades, Long>, TradeQuer
 	@Query("""
 		SELECT t FROM Trades t
 		WHERE t.isDeleted = false AND t.status <> 'REJECTED'
-		AND (t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId)
-		OR (t.requestedGoods.id = :goodsId AND t.targetGoods.user.usersId = :userId)
+		AND ((t.targetGoods.id = :goodsId AND t.requestedGoods.user.usersId = :userId)
+		OR (t.requestedGoods.id = :goodsId AND t.targetGoods.user.usersId = :userId))
 		ORDER BY t.updatedAt DESC""")
 	Optional<Trades> findUserRelatedTrade(@Param("goodsId") Long goodsId, @Param("userId") Long userId);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## 📝 작업 내용
- 물건 상세 조회에서 연결된 swap이 조회될 때 rejected되지 않은 것만 조회하는 것으로 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

-

## 💬 리뷰 요구사항(선택)
없습니다!
