### PR TITLE
[fix] 물건 목록 조회에 goodsTradeStatus 필드 추가

### DIFF
--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -34,7 +34,6 @@ public enum ErrorCode {
 	// image error
 	IMAGE_READ_FAILED(HttpStatus.BAD_REQUEST, "이미지를 읽는데 실패하였습니다."),
 	IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 이미지 업로드에 실패했습니다. 다시 시도해주세요."),
-	S3_NETWORK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 통신에 실패했습니다."),
 	IMAGE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지는 최대 10개까지 올릴 수 있습니다."),
 	FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 최대 한도를 초과했습니다. (5MB)"),
 	INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "파일 확장자는 JPG, JPEG, PNG만 가능합니다."),
@@ -54,9 +53,6 @@ public enum ErrorCode {
 	// trades error
 	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
 	TRADE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "거래에 대한 권한이 없습니다."),
-	DUPLICATE_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "이미 해당 물건에 스왑 요청한 내역이 있습니다."),
-	TRADE_ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "이미 해당 거래에 대해 요청을 받은 건이 존재합니다."),
-	TRADE_ALREADY_REJECTED_WITH_SAME_GOODS(HttpStatus.BAD_REQUEST, "같은 물건 조합으로 이미 거절된 거래 요청이 존재합니다."),
 	MAXIMUM_TRADE_REQUEST(HttpStatus.BAD_REQUEST, "가능한 스왑 요청 횟수를 초과하였습니다."),
 
 	// chat error

--- a/src/main/java/com/example/swapit/domain/dto/good/GoodsDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/good/GoodsDto.java
@@ -18,6 +18,7 @@ public class GoodsDto {
 	private String title;
 	private long price;
 	private String category;
+	private String goodsTradeStatus;
 	private String imageUrl;
 	private String placeName;
 	private long viewCount;
@@ -29,6 +30,7 @@ public class GoodsDto {
 			.title(good.getTitle())
 			.price(good.getPrice())
 			.category(good.getCategory().getName())
+			.goodsTradeStatus(good.getGoodsTradeStatus().name())
 			.imageUrl(imageUrl)
 			.placeName(good.getPlaceName())
 			.viewCount(good.getViewCount())

--- a/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/GoodsControllerTest.java
@@ -1,8 +1,8 @@
 package com.example.swapit.controller;
 
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -64,10 +64,10 @@ class GoodsControllerTest {
 		LocalDateTime tenMinutesAgo = LocalDateTime.now().minus(10, ChronoUnit.MINUTES);
 
 		GoodsDto dto1 = new GoodsDto(
-			1L, "아이폰 15", 2500L, "NEW", null, null, 10L, now
+			1L, "아이폰 15", 2500L, "NEW", GoodsTradeStatus.AVAILABLE.name(), null, null, 10L, now
 		);
 		GoodsDto dto2 = new GoodsDto(
-			2L, "갤럭시 S25", 1300L, "FAIR", null, null, 100L, tenMinutesAgo
+			2L, "갤럭시 S25", 1300L, "FAIR", GoodsTradeStatus.AVAILABLE.name(), null, null, 100L, tenMinutesAgo
 		);
 
 		GoodsListDto mockGoodsList = new GoodsListDto(List.of(dto1, dto2), true, 2L, 2);

--- a/src/test/java/com/example/swapit/docs/GoodsControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/GoodsControllerDocsTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.example.swapit.controller.GoodsController;
+import com.example.swapit.domain.GoodsTradeStatus;
 import com.example.swapit.domain.dto.Dto;
 import com.example.swapit.domain.dto.good.GoodsDto;
 import com.example.swapit.domain.dto.good.GoodsListDto;
@@ -42,7 +43,7 @@ public class GoodsControllerDocsTest extends RestDocsTest {
 	void getAllGoods() throws Exception {
 		// given
 		GoodsDto sampleGood = new GoodsDto(
-			1L, "스타벅스 머그컵", 15000L, "MISC", "cup-image.jpg", "용산구",
+			1L, "스타벅스 머그컵", 15000L, "MISC", GoodsTradeStatus.RESERVED.name(), "cup-image.jpg", "용산구",
 			2300L, LocalDateTime.now());
 		GoodsListDto response = new GoodsListDto(
 			List.of(sampleGood), true, 5L, 10);
@@ -102,6 +103,8 @@ public class GoodsControllerDocsTest extends RestDocsTest {
 						fieldWithPath("results.goodsList[].title").type(JsonFieldType.STRING).description("물건 제목"),
 						fieldWithPath("results.goodsList[].price").type(JsonFieldType.NUMBER).description("물건 가격"),
 						fieldWithPath("results.goodsList[].category").type(JsonFieldType.STRING).description("물건 카테고리"),
+						fieldWithPath("results.goodsList[].goodsTradeStatus").type(JsonFieldType.STRING)
+							.description("물건 거래가능 상태"),
 						fieldWithPath("results.goodsList[].imageUrl").type(JsonFieldType.STRING)
 							.description("물건 이미지 URL"),
 						fieldWithPath("results.goodsList[].placeName").type(JsonFieldType.STRING).description("거래 위치"),


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 📝 작업 내용
- 물건 목록 조회에 goodsTradeStatus 필드 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify


## 💬 리뷰 요구사항(선택)
없습니다!
