### PR TITLE
[fix] 거래 완료 시 채팅 전송

### DIFF
--- a/src/main/java/com/example/swapit/domain/dto/chat/ChatStompResponseDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ChatStompResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.example.swapit.domain.ChatType;
 import com.example.swapit.domain.Chats;
+import com.example.swapit.domain.dto.RequesterGoodsDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,13 +16,15 @@ public class ChatStompResponseDto {
 	private Long senderId;
 	private ChatType chatType;
 	private String content;
+	private RequesterGoodsDto requesterGoods;
 	private LocalDateTime createdAt;
 
-	public ChatStompResponseDto(Chats chats) {
+	public ChatStompResponseDto(Chats chats, RequesterGoodsDto requesterGoods) {
 		this.chatsId = chats.getId();
 		this.senderId = chats.getSender().getUsersId();
 		this.chatType = chats.getChatType();
 		this.content = chats.getContent();
+		this.requesterGoods = requesterGoods;
 		this.createdAt = chats.getCreatedAt();
 	}
 }

--- a/src/main/java/com/example/swapit/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/ChatServiceImpl.java
@@ -177,13 +177,25 @@ public class ChatServiceImpl implements ChatService {
 			.goodsId(chatDto.getGoodsId())
 			.build();
 
+		RequesterGoodsDto requesterGoods = null;
+		if (ChatType.REQUEST.equals(chats.getChatType()) || ChatType.ACCEPT.equals(chats.getChatType())) {
+			Goods goods = goodsRepository.findById(chats.getGoodsId())
+				.orElseThrow(() -> new CustomException(ErrorCode.GOOD_NOT_FOUND));
+
+			requesterGoods = new RequesterGoodsDto(
+				goods.getId(),
+				goods.getTitle(),
+				goods.getUser().getNickname()
+			);
+		}
+
 		chatRepository.save(chats);
 
 		// 알림 발행
 		Long receiverId = chatRooms.getCounterpartId(sender.getUsersId());
 		notificationEventPublisher.publishNotification(receiverId, NotificationType.CHAT, chatroomId);
 
-		return new ChatStompResponseDto(chats);
+		return new ChatStompResponseDto(chats, requesterGoods);
 	}
 
 	@Override

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -208,6 +208,12 @@ public class TradesServiceImpl implements TradesService {
 		trade.getRequestedGoods().setGoodsTradeStatus(GoodsTradeStatus.SOLDOUT);
 		goodsRepository.save(trade.getRequestedGoods());
 
+		// 채팅방이 있으면 메시지 전송
+		Optional<ChatRooms> chatRoomsOpt = chatRoomsRepository.findByTrade(trade);
+		chatRoomsOpt.ifPresent(
+			rooms -> updateChatroomAndSendChat(rooms, null, ChatType.COMPLETE, trade.getRequestedGoods())
+		);
+
 		// 거래 상대방에게 알림 전송
 		Long tradingPartnerId = trade.getTradingPartnerId(userId);
 		notificationEventPublisher.publishNotification(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없습니다!

## 📝 작업 내용

> 거래 완료 시 채팅 전송되게 추가, 채팅 메시지 응답과 웹소켓 응답 일치하도록 처리

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 없습니다!

## 💬 리뷰 요구사항(선택)

> 없습니다!

> RequesterGoods가 있을 때 웹소켓 응답

![스크린샷 2025-04-10 오후 5 17 54](https://github.com/user-attachments/assets/8f73fba9-dacb-43dd-b968-4a3dd0f7bf09)

> RequesterGoods가 null일 때 웹소켓 응답

![스크린샷 2025-04-10 오후 5 18 16](https://github.com/user-attachments/assets/1e846c32-84b8-435f-b715-c8b31f33765c)