### PR TITLE
[fix] 웹소켓 핸드셰이크에서 principal 설정하도록 로직 추가

### DIFF
--- a/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/swapit/config/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/user/auth/logout",
 		"/api/all/auth/info",
 		"/api/all/sample",
-		"/ws",
 		"/docs",
 		"/swagger-ui",
 		"/v3/api-docs"

--- a/src/main/java/com/example/swapit/config/websocket/JwtHandshakeHandler.java
+++ b/src/main/java/com/example/swapit/config/websocket/JwtHandshakeHandler.java
@@ -1,0 +1,58 @@
+package com.example.swapit.config.websocket;
+
+import java.security.Principal;
+import java.util.Map;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import com.example.swapit.common.exception.CustomException;
+import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.config.security.jwt.JwtProvider;
+import com.example.swapit.domain.Users;
+import com.example.swapit.repository.UsersRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeHandler extends DefaultHandshakeHandler {
+	
+	private final JwtProvider jwtProvider;
+	private final UsersRepository usersRepository;
+
+	@Override
+	protected Principal determineUser(ServerHttpRequest request,
+		WebSocketHandler wsHandler,
+		Map<String, Object> attributes) {
+
+		HttpServletRequest servletRequest = ((ServletServerHttpRequest)request).getServletRequest();
+		String authHeader = servletRequest.getHeader("Authorization");
+
+		if (authHeader != null && authHeader.startsWith("Bearer ")) {
+			String token = authHeader.substring(7);
+
+			if (jwtProvider.validateToken(token)) {
+				String email = jwtProvider.getEmailFromToken(token);
+				Users user = usersRepository.findByEmail(email)
+					.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+				String userIdStr = user.getUsersId().toString();
+				log.info("[Handshake] 유저 인증 성공: userId={}", userIdStr);
+				return new StompPrincipal(userIdStr); // SimpUser.getName()이 이 값이 됨
+			} else {
+				log.warn("[Handshake] JWT 유효성 실패");
+			}
+		} else {
+			log.warn("[Handshake] Authorization 헤더 없음");
+		}
+
+		return null; // 인증 실패 → WebSocket 연결 안 됨
+	}
+}

--- a/src/main/java/com/example/swapit/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/swapit/config/websocket/StompHandler.java
@@ -77,11 +77,6 @@ public class StompHandler implements ChannelInterceptor {
 		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
 		if (!subscribedList.contains(dest)) {
 			subscribedList.add(dest);
-			// /topic/chat/read/{roomId}도 같이 추가.
-			if (dest.startsWith("/topic/chat/")) {
-				String roomId = dest.substring("/topic/chat/".length());
-				subscribedList.add("/topic/chat/read/" + roomId);
-			}
 		}
 
 		log.debug("[SUBSCRIBE] 유저id={}, 세션={}, dest={}", accessor.getUser().getName(),
@@ -94,11 +89,6 @@ public class StompHandler implements ChannelInterceptor {
 
 		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
 		subscribedList.remove(dest);
-		// /topic/chat/read/{roomId}도 같이 제거
-		if (dest.startsWith("/topic/chat/")) {
-			String roomId = dest.substring("/topic/chat/".length());
-			subscribedList.remove("/topic/chat/read/" + roomId);
-		}
 
 		log.debug("[UNSUBSCRIBE] 유저id={}, 세션={}, dest={}", accessor.getUser().getName(),
 			accessor.getSessionId(), dest);
@@ -112,7 +102,7 @@ public class StompHandler implements ChannelInterceptor {
 		String subscribeDest = dest.replaceFirst("^/app", "/topic");
 
 		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
-		if (!subscribedList.contains(subscribeDest)) {
+		if (!subscribeDest.startsWith("/topic/chat/read/") && !subscribedList.contains(subscribeDest)) {
 			// payload 변환
 			Object payload = message.getPayload();
 			String payloadStr = null;

--- a/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	private final StompHandler stompHandler; // jwt 인증
+	private final JwtHandshakeHandler jwtHandshakeHandler;
 
 	@Bean
 	public TaskScheduler taskScheduler() {
@@ -40,7 +41,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws")
-			// .addInterceptors(jwtHandshakeInterceptor) // todo: 앱 연결 후, handshake interceptor로 변환
+			.setHandshakeHandler(jwtHandshakeHandler) // todo: 앱 연결 후, handshake interceptor로 변환
 			.setAllowedOrigins("*"); // cors
 	}
 

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
@@ -54,7 +54,7 @@ public class NotificationEventListener {
 		NotificationDto notiDto = NotificationDto.of(noti);
 		String userKey = userId.toString();
 		SimpUser simpUser = simpUserRegistry.getUser(userKey);
-		log.debug("[WS 유저 조회] userId={}, simpUser 존재 여부={}, simpUser.getName()={}", userKey, simpUser != null,
+		log.debug("[WS 유저 조회] userId={},  simpUser.getName()={}", userKey,
 			simpUser != null ? simpUser.getName() : "없음");
 
 		boolean isSubscribed = false;

--- a/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/example/swapit/service/notification/NotificationEventListenerTest.java
@@ -13,6 +13,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
@@ -20,7 +23,6 @@ import com.example.swapit.domain.NotificationEvent;
 import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.Notifications;
 import com.example.swapit.domain.Users;
-import com.example.swapit.domain.dto.NotificationDto;
 import com.example.swapit.repository.FcmTokenRepository;
 import com.example.swapit.repository.NotificationRepository;
 import com.example.swapit.repository.UsersRepository;
@@ -42,6 +44,15 @@ class NotificationEventListenerTest {
 
 	@Mock
 	private FcmCustomNotificationServiceImpl fcmNotificationService;
+
+	@Mock
+	private SimpUserRegistry simpUserRegistry;
+
+	@Mock
+	private SimpUser simpUser;
+
+	@Mock
+	private SimpSession simpSession;
 
 	@InjectMocks
 	private NotificationEventListener notificationEventListener;
@@ -82,14 +93,19 @@ class NotificationEventListenerTest {
 	@DisplayName("FCM 토큰이 없을 때, 에러.")
 	void testHandleNotification_FCMTokenNotFound() {
 		// Given
-		when(usersRepository.findById(1L)).thenReturn(Optional.of(testUser));
-		when(notificationRepository.save(any(Notifications.class))).thenReturn(testNotification);
+		Long userId = 1L;
+
+		Users testUser = Users.builder()
+			.usersId(userId)
+			.notificationEnabled(true)
+			.build();
+
+		when(usersRepository.findById(userId)).thenReturn(Optional.of(testUser));
+		when(notificationRepository.save(any(Notifications.class))).thenReturn(mock(Notifications.class));
 		when(fcmTokenRepository.findByUser(testUser)).thenReturn(Optional.empty());
 
-		// 웹소켓 실패 시 FCM 시도 (그러나 토큰 없음)
-		doThrow(new RuntimeException("WebSocket Error"))
-			.when(messagingTemplate)
-			.convertAndSendToUser(eq("1"), eq("/queue/notifications"), any(NotificationDto.class));
+		// Simulate user not connected → simpUserRegistry returns null
+		when(simpUserRegistry.getUser(String.valueOf(userId))).thenReturn(null);
 
 		// When
 		assertDoesNotThrow(() -> {
@@ -97,8 +113,9 @@ class NotificationEventListenerTest {
 		});
 
 		// Then
-		verify(messagingTemplate, times(1))
-			.convertAndSendToUser(eq("1"), eq("/queue/notifications"), any(NotificationDto.class));
-		verify(fcmNotificationService, never()).sendFcmNotification(anyString(), any(Notifications.class));
+		verify(messagingTemplate, never())
+			.convertAndSendToUser(anyString(), anyString(), any());
+		verify(fcmNotificationService, never())
+			.sendFcmNotification(anyString(), any(Notifications.class));
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 📝 작업 내용
- 웹소켓 핸드셰이크에서 jwt 검증 후, principal 설정.
- api에서 /ws 도 jwt 검증하도록 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- 없습니다!

## 💬 리뷰 요구사항(선택)
없습니다!
