### PR TITLE
fix : fcm 전송 시, title, body만 전송하도록 변경

### DIFF
--- a/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/notification/FcmCustomNotificationServiceImpl.java
@@ -48,7 +48,6 @@ public class FcmCustomNotificationServiceImpl implements FcmNotificationService 
 					.setTitle(noti.getTitle())
 					.setBody(noti.getBody())
 					.build())
-			.putAllData(data)
 			.setAndroidConfig(
 				AndroidConfig.builder()
 					.setPriority(AndroidConfig.Priority.HIGH)


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 📝 작업 내용
- fcm 알림 보낼 때 data 빼고 보내는 걸로 임시 변경

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
