### PR TITLE
[fix] 채팅 알림 전송 시, 해당 채팅방에 구독 중이라면 알림 보내지 않도록 수정

### DIFF
--- a/src/main/java/com/example/swapit/config/websocket/WebsocketDestination.java
+++ b/src/main/java/com/example/swapit/config/websocket/WebsocketDestination.java
@@ -1,0 +1,17 @@
+package com.example.swapit.config.websocket;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum WebsocketDestination {
+	NOTIFICATION_QUEUE("/user/queue/notifications"),
+	CHAT_TOPIC("/topic/chat/");
+
+	private final String path;
+
+	public String withKey(String key) {
+		return path + key;
+	}
+}

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
@@ -12,6 +12,7 @@ import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.config.websocket.WebsocketDestination;
 import com.example.swapit.domain.NotificationEvent;
+import com.example.swapit.domain.NotificationType;
 import com.example.swapit.domain.Notifications;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.NotificationDto;
@@ -51,13 +52,20 @@ public class NotificationEventListener {
 			return;
 		}
 
-		// 웹소켓 알림 전송 (앱이 온라인 상태) : "/user/queue/notifications" 구독된 상태
+		// 웹소켓 알림 전송 (앱이 온라인 상태)
 		NotificationDto notiDto = NotificationDto.of(noti);
 		String userKey = userId.toString();
 
-		boolean isNotiSubscribed = isSubscribedToNotifications(userKey);
+		// CHAT 알림 -> 채팅방 구독 중이면 알림 생략
+		if (noti.getType().equals(NotificationType.CHAT)) {
+			String chatTopic = WebsocketDestination.CHAT_TOPIC.withKey(noti.getRelatedData().toString());
+			if (isSubscribed(userKey, chatTopic)) {
+				log.debug("[CHAT 알림 무시] 유저 {}가 채팅방 {} 구독 중 → 알림 전송 생략", userId, noti.getRelatedData().toString());
+				return;
+			}
+		}
 
-		if (isNotiSubscribed) {
+		if (isSubscribed(userKey, WebsocketDestination.NOTIFICATION_QUEUE.getPath())) {
 			messagingTemplate.convertAndSendToUser(userKey, "/queue/notifications", notiDto);
 			log.debug("[WS알림 전송] 유저id={}, payload={} ", userId, notiDto);
 		} else {
@@ -66,7 +74,7 @@ public class NotificationEventListener {
 		}
 	}
 
-	private boolean isSubscribedToNotifications(String userKey) {
+	private boolean isSubscribed(String userKey, String destination) {
 		SimpUser user = simpUserRegistry.getUser(userKey);
 		log.debug("[WS 유저 조회] userId={}, simpUser.getName()={}", userKey,
 			user != null ? user.getName() : "없음");
@@ -78,7 +86,7 @@ public class NotificationEventListener {
 			log.debug("[WS 세션] sessionId={}, subscription 수={}", session.getId(),
 				session.getSubscriptions().size());
 			for (SimpSubscription sub : session.getSubscriptions()) {
-				if (WebsocketDestination.NOTIFICATION_QUEUE.getPath().equals(sub.getDestination())) {
+				if (destination.equals(sub.getDestination())) {
 					return true;
 				}
 			}

--- a/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
+++ b/src/main/java/com/example/swapit/service/notification/NotificationEventListener.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.example.swapit.common.exception.CustomException;
 import com.example.swapit.common.exception.ErrorCode;
+import com.example.swapit.config.websocket.WebsocketDestination;
 import com.example.swapit.domain.NotificationEvent;
 import com.example.swapit.domain.Notifications;
 import com.example.swapit.domain.Users;
@@ -53,33 +54,36 @@ public class NotificationEventListener {
 		// 웹소켓 알림 전송 (앱이 온라인 상태) : "/user/queue/notifications" 구독된 상태
 		NotificationDto notiDto = NotificationDto.of(noti);
 		String userKey = userId.toString();
-		SimpUser simpUser = simpUserRegistry.getUser(userKey);
-		log.debug("[WS 유저 조회] userId={},  simpUser.getName()={}", userKey,
-			simpUser != null ? simpUser.getName() : "없음");
 
-		boolean isSubscribed = false;
+		boolean isNotiSubscribed = isSubscribedToNotifications(userKey);
 
-		if (simpUser != null) {
-			sessionLoop:
-			for (SimpSession session : simpUser.getSessions()) {
-				log.debug("[WS 세션] sessionId={}, subscription 수={}", session.getId(),
-					session.getSubscriptions().size());
-				for (SimpSubscription sub : session.getSubscriptions()) {
-					if ("/user/queue/notifications".equals(sub.getDestination())) {
-						isSubscribed = true;
-						break sessionLoop;
-					}
-				}
-			}
-		}
-
-		if (isSubscribed) {
+		if (isNotiSubscribed) {
 			messagingTemplate.convertAndSendToUser(userKey, "/queue/notifications", notiDto);
 			log.debug("[WS알림 전송] 유저id={}, payload={} ", userId, notiDto);
 		} else {
 			log.debug("[WS알림 스킵] 유저id={}는 현재 오프라인 상태 → FCM 전송", userId);
 			sendFcm(user, noti);
 		}
+	}
+
+	private boolean isSubscribedToNotifications(String userKey) {
+		SimpUser user = simpUserRegistry.getUser(userKey);
+		log.debug("[WS 유저 조회] userId={}, simpUser.getName()={}", userKey,
+			user != null ? user.getName() : "없음");
+
+		if (user == null)
+			return false;
+
+		for (SimpSession session : user.getSessions()) {
+			log.debug("[WS 세션] sessionId={}, subscription 수={}", session.getId(),
+				session.getSubscriptions().size());
+			for (SimpSubscription sub : session.getSubscriptions()) {
+				if (WebsocketDestination.NOTIFICATION_QUEUE.getPath().equals(sub.getDestination())) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	private void sendFcm(Users user, Notifications noti) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #164 

## 📝 작업 내용
- 알림 구독 확인 로직 메소드 분리
- 알림 발생 시 채팅알림이면, 해당 채팅방을 구독하고 있는지 검증 추가

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- 없습니다!

## 💬 리뷰 요구사항(선택)
변경 전 : 총 2번 메세지 옴. (채팅방, 알림)
![image](https://github.com/user-attachments/assets/ca093c12-54d5-4e54-a46a-58caa9f44f9c)

변경 후 : 메세지가 채팅방에서만 옴.
![image](https://github.com/user-attachments/assets/f8fd5f8e-2085-49fc-8bd7-cf23c4dea759)

