### PR TITLE
[fix] 마지막 메세지 id를 dto로 받을 때 생성자 추가 및 로그 추가

### DIFF
--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,12 +46,14 @@ public class ChatWebSocketController {
 	}
 
 	@MessageMapping("/chat/read/{chatroomId}")
-	public void updateReadReceipt(@DestinationVariable Long chatroomId, ReadReceiptRequestDto receipt,
+	public void updateReadReceipt(@DestinationVariable Long chatroomId, @Payload ReadReceiptRequestDto receipt,
 		Principal principal) {
 		if (principal == null) {
 			log.error("[ERROR] WebSocket 읽음 이벤트 처리 실패: Principal이 null입니다.");
 			return;
 		}
+
+		log.debug("[WS 마지막메세지 id 저장] chatroomId={}, payload={}", chatroomId, receipt);
 
 		Long userId = Long.parseLong(principal.getName());
 		chatService.updateReadReceipt(chatroomId, userId, receipt.getLastReadChatId());

--- a/src/main/java/com/example/swapit/domain/dto/chat/ReadReceiptRequestDto.java
+++ b/src/main/java/com/example/swapit/domain/dto/chat/ReadReceiptRequestDto.java
@@ -1,10 +1,12 @@
 package com.example.swapit.domain.dto.chat;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@RequiredArgsConstructor
-@Getter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReadReceiptRequestDto {
 	private Long lastReadChatId;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 📝 작업 내용
- 마지막 메세지 id를 입력받는 dto에 기본 생성자, 전체 생성자 추가
  - 생성자를 추가한 이유 : json 역직렬화가 잘 되지 않아서 그런지, stompHandler에는 로그로 마지막 메세지 id 보낸 로그가 찍히는데, db에는 바뀌지 않아 추가함.

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- 없습니다!

## 💬 리뷰 요구사항(선택)
기존에 이 부분이 없을 때도 잘 존재했던 부분이어서, 불필요해보이지만 현재 안드로이드 구조를 바꿨을 때 안되는 이유가 이걸로 추정되어서 추가합니다!
![image](https://github.com/user-attachments/assets/b0f7ab09-1f9b-486d-a435-6960397256ed)
