### PR TITLE
[fix] 거래중인 스왑 있으면 탈퇴 불가능 처리

### DIFF
--- a/src/main/java/com/example/swapit/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/swapit/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
 	GET_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "사용자 정보 조회에 실패했습니다."),
 	LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
 	SOCIAL_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "소셜 연결 해제에 실패했습니다."),
+	EXIST_INPROGRESS_TRADE(HttpStatus.BAD_REQUEST, "거래중인 스왑이 있어 회원 탈퇴에 실패했습니다."),
 
 	// trades error
 	TRADES_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),

--- a/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
+++ b/src/main/java/com/example/swapit/repository/trade/TradesRepository.java
@@ -77,4 +77,9 @@ public interface TradesRepository extends JpaRepository<Trades, Long>, TradeQuer
 		   + "WHERE t.targetGoods = :target AND t.requestedGoods = :request AND t.status = 'INPROGRESS'")
 	boolean existsInProgressTrade(@Param("target") Goods target, @Param("request") Goods request);
 
+	@Query("""
+		SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Trades t
+		WHERE t.status = 'INPROGRESS' AND (t.requestedGoods.user = :users OR t.targetGoods.user = :users)
+		""")
+	boolean existsInProgressTradeByUser(@Param("users") Users users);
 }

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -216,8 +216,32 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	@Transactional
 	public void withdrawGoogleUser(String googleToken, String reason) {
+		Users user = currentUserService.getCurrentUser();
+
+		// 거래중인 스왑 있으면 탈퇴 불가능 처리
+		if (tradesRepository.existsInProgressTradeByUser(user)) {
+			throw new CustomException(ErrorCode.EXIST_INPROGRESS_TRADE);
+		}
+
+		callGoogleRevoke(googleToken);
+		userWithdraw(reason, user);
+	}
+
+	@Override
+	public void withdrawKakaoUser(String kakaoToken, String reason) {
+		Users user = currentUserService.getCurrentUser();
+
+		// 거래중인 스왑 있으면 탈퇴 불가능 처리
+		if (tradesRepository.existsInProgressTradeByUser(user)) {
+			throw new CustomException(ErrorCode.EXIST_INPROGRESS_TRADE);
+		}
+
+		callKakaoRevoke(kakaoToken);
+		userWithdraw(reason, user);
+	}
+
+	public void callGoogleRevoke(String googleToken) {
 		RestTemplate restTemplate = new RestTemplate();
 		String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + googleToken;
 
@@ -229,12 +253,9 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 		log.info("구글 연결 해제 성공");
-		userWithdraw(reason);
 	}
 
-	@Override
-	@Transactional
-	public void withdrawKakaoUser(String kakaoToken, String reason) {
+	public void callKakaoRevoke(String kakaoToken) {
 		RestTemplate restTemplate = new RestTemplate();
 		HttpHeaders headers = new HttpHeaders();
 		headers.setBearerAuth(kakaoToken);
@@ -249,13 +270,10 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 		log.info("카카오 연결 해제 성공");
-		userWithdraw(reason);
 	}
 
 	@Transactional
-	public void userWithdraw(String reason) {
-		Users user = currentUserService.getCurrentUser();
-
+	public void userWithdraw(String reason, Users user) {
 		// FCM 토큰, 리프레시 토큰, 알림
 		fcmTokenRepository.deleteByUser(user);
 		tokensRepository.deleteByUser(user);

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -573,7 +573,7 @@ public class AuthServiceTest {
 		String reason = "테스트 탈퇴 사유";
 
 		// userWithdraw() 메서드 실행 (내부에서 S3 삭제 메서드도 호출됨)
-		authService.userWithdraw(reason);
+		authService.userWithdraw(reason, testUser);
 
 		// FCM 토큰, 리프레시 토큰, 알림 삭제 검증
 		verify(fcmTokenRepository).deleteByUser(testUser);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없습니다!

## 📝 작업 내용

> 거래중인 스왑 있으면 탈퇴 불가능 처리
> 회원 탈퇴 로직 - 외부 api 호출, 회원 데이터 삭제 로직 분리

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 이번 PR에서 수정된 테이블이 있는지 작성해주세요.
> 수정사항이 있다면, pr 올린 사람이 해당 부분을 반영할 때까지 merge 하지 말아주십시오!

- 없습니다!

## 💬 리뷰 요구사항(선택)

> 거래중인 스왑을 조회할 때, 거래 관련 물건의 유저만 확인하면 되는건지 한 번 봐주시면 감사하겠습니다!
> 현재 로직으로는 회원 정보 삭제가 실패하면, 외부 소셜과의 연결은 끊겼는데 db에는 정보가 남아있는 상태입니다. 그래서 재시도를 하거나 스케쥴러로 관리하는 추가적인 방법이 필요할지 고민이네요. 회원 탈퇴에 추가적으로 시간을 써야되는게 맞나 싶습니다...
