### PR TITLE
[feat] 구독 해제 기능 명시적으로 추가

### DIFF
--- a/src/main/java/com/example/swapit/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/swapit/config/websocket/StompHandler.java
@@ -3,8 +3,6 @@ package com.example.swapit.config.websocket;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -21,6 +19,7 @@ import com.example.swapit.common.exception.ErrorCode;
 import com.example.swapit.config.security.jwt.JwtProvider;
 import com.example.swapit.domain.Users;
 import com.example.swapit.repository.UsersRepository;
+import com.example.swapit.service.chat.StompSubscriptionService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +31,7 @@ public class StompHandler implements ChannelInterceptor {
 
 	private final JwtProvider jwtProvider;
 	private final UsersRepository usersRepository;
-	private static final String SUBSCRIBED_SET_KEY = "subscribedSet";
+	private final StompSubscriptionService subscriptionService;
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -49,7 +48,6 @@ public class StompHandler implements ChannelInterceptor {
 		switch (command) {
 			case CONNECT -> handleConnect(accessor, token);
 			case SUBSCRIBE -> handleSubscribe(accessor);
-			case UNSUBSCRIBE -> handleUnsubscribe(accessor);
 			case SEND -> {
 				return handleSend(message, accessor);
 			}
@@ -58,59 +56,34 @@ public class StompHandler implements ChannelInterceptor {
 	}
 
 	private void handleConnect(StompHeaderAccessor accessor, String token) {
-		String onlyToken = token.replace("Bearer ", "");
+		String onlyToken = token.replaceFirst("Bearer ", "");
 		validateToken(onlyToken);
 		Users user = usersRepository.findById(Long.valueOf(jwtProvider.getIdFromToken(onlyToken)))
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 		setSessionFromPrincipal(accessor, user.getUsersId());
 
-		// 세션 속성에 빈 구독 set 추가 (동시성 안전) : 순서 상관없을 것 같아서 일단 set으로 설정
-		accessor.getSessionAttributes().put(SUBSCRIBED_SET_KEY, ConcurrentHashMap.newKeySet());
-
 		log.debug("[CONNECT] 유저id={}, 세션={}, token={}", user.getUsersId(), accessor.getSessionId(), token);
 	}
 
 	private void handleSubscribe(StompHeaderAccessor accessor) {
+		log.debug("subscribe 추적");
 		setPrincipalFromSession(accessor);
-		String dest = accessor.getDestination();
+		String dest = normalizeDestination(accessor.getDestination());
+		Long userId = Long.parseLong(accessor.getUser().getName());
 
-		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
-		if (!subscribedList.contains(dest)) {
-			subscribedList.add(dest);
-		}
+		subscriptionService.subscribe(userId, dest);
 
-		log.debug("[SUBSCRIBE] 유저id={}, 세션={}, dest={}", accessor.getUser().getName(),
-			accessor.getSessionId(), dest);
-	}
-
-	private void handleUnsubscribe(StompHeaderAccessor accessor) {
-		setPrincipalFromSession(accessor);
-		String dest = accessor.getDestination();
-
-		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
-		subscribedList.remove(dest);
-
-		log.debug("[UNSUBSCRIBE] 유저id={}, 세션={}, dest={}", accessor.getUser().getName(),
+		log.debug("[SUBSCRIBE] 유저id={}, 세션={}, dest={}", userId,
 			accessor.getSessionId(), dest);
 	}
 
 	private Message<?> handleSend(Message<?> message, StompHeaderAccessor accessor) {
 		setPrincipalFromSession(accessor);
-		String dest = accessor.getDestination();
+		Long userId = Long.parseLong(accessor.getUser().getName());
+		String dest = normalizeDestination(accessor.getDestination());
 
-		// /app -> /topic 변환
-		String subscribeDest = dest.replaceFirst("^/app", "/topic");
-
-		Set<String> subscribedList = getOrInitSubscribedSet(accessor);
-		if (!subscribeDest.startsWith("/topic/chat/read/") && !subscribedList.contains(subscribeDest)) {
-			// payload 변환
-			Object payload = message.getPayload();
-			String payloadStr = null;
-			if (payload instanceof byte[] byteArray) {
-				payloadStr = new String(byteArray, java.nio.charset.StandardCharsets.UTF_8);
-			} else {
-				payloadStr = payload.toString();
-			}
+		if (!isAllowedToSend(userId, dest)) {
+			String payloadStr = extractPayloadString(message);
 
 			log.warn("[SEND 차단] 유저id={}, 세션={}, dest={}, payload={} → 구독되지 않은 대상",
 				accessor.getUser().getName(), accessor.getSessionId(), dest, payloadStr);
@@ -125,10 +98,21 @@ public class StompHandler implements ChannelInterceptor {
 		return MessageBuilder.createMessage(message.getPayload(), new MessageHeaders(newHeaders));
 	}
 
-	@SuppressWarnings("unchecked")
-	private Set<String> getOrInitSubscribedSet(StompHeaderAccessor accessor) {
-		Map<String, Object> session = accessor.getSessionAttributes();
-		return (Set<String>)session.computeIfAbsent(SUBSCRIBED_SET_KEY, k -> ConcurrentHashMap.newKeySet());
+	private boolean isAllowedToSend(Long userId, String destination) {
+		// 예외 목적지 허용
+		if (destination.startsWith("/chat/read/") || destination.startsWith("/chat/unsubscribe/")) {
+			return true;
+		}
+		return subscriptionService.isSubscribed(userId, destination);
+	}
+
+	private String extractPayloadString(Message<?> message) {
+		Object payload = message.getPayload();
+		if (payload instanceof byte[] byteArray) {
+			return new String(byteArray, java.nio.charset.StandardCharsets.UTF_8);
+		} else {
+			return payload.toString();
+		}
 	}
 
 	private void validateToken(String token) {
@@ -136,6 +120,12 @@ public class StompHandler implements ChannelInterceptor {
 			log.error("[CONNECT 오류] JWT 검증 실패");
 			throw new CustomException(ErrorCode.VALIDATION_FAIL);
 		}
+	}
+
+	private String normalizeDestination(String destination) {
+		if (destination == null || destination.trim().isEmpty())
+			return null;
+		return destination.replaceFirst("^/app", "").replaceFirst("^/topic", "");
 	}
 
 	private void setSessionFromPrincipal(StompHeaderAccessor accessor, Long userId) {

--- a/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/example/swapit/config/websocket/WebSocketConfig.java
@@ -41,7 +41,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws")
-			.setHandshakeHandler(jwtHandshakeHandler) // todo: 앱 연결 후, handshake interceptor로 변환
+			.setHandshakeHandler(jwtHandshakeHandler)
 			.setAllowedOrigins("*"); // cors
 	}
 

--- a/src/main/java/com/example/swapit/controller/ChatController.java
+++ b/src/main/java/com/example/swapit/controller/ChatController.java
@@ -15,7 +15,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromGoodDto;
 import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomListResponseDto;
-import com.example.swapit.service.ChatService;
+import com.example.swapit.service.chat.ChatService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -16,6 +16,7 @@ import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
 import com.example.swapit.domain.dto.chat.ReadReceiptRequestDto;
 import com.example.swapit.service.chat.ChatService;
+import com.example.swapit.service.chat.StompSubscriptionService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatWebSocketController {
 	private final SimpMessagingTemplate template;
 	private final ChatService chatService;
+	private final StompSubscriptionService subscriptionService;
 
 	@MessageMapping("/chat/{chatroomId}")
 	@SendTo("/topic/chat/{chatroomId}")
@@ -57,5 +59,14 @@ public class ChatWebSocketController {
 
 		Long userId = Long.parseLong(principal.getName());
 		chatService.updateReadReceipt(chatroomId, userId, receipt.getLastReadChatId());
+	}
+
+	@MessageMapping("/chat/unsubscribe/{chatroomId}")
+	public void unsubscribe(@DestinationVariable Long chatroomId, Principal principal) {
+		Long userId = Long.parseLong(principal.getName());
+		String dest = "/chat/" + chatroomId;
+
+		subscriptionService.unsubscribe(userId, dest);
+		log.debug("[UNSUBSCRIBE] 유저id={}, dest={}", userId, dest);
 	}
 }

--- a/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
+++ b/src/main/java/com/example/swapit/controller/ChatWebSocketController.java
@@ -15,7 +15,7 @@ import com.example.swapit.config.websocket.StompPrincipal;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
 import com.example.swapit.domain.dto.chat.ReadReceiptRequestDto;
-import com.example.swapit.service.ChatService;
+import com.example.swapit.service.chat.ChatService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/swapit/service/TradesServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/TradesServiceImpl.java
@@ -34,6 +34,7 @@ import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
+import com.example.swapit.service.chat.ChatSendService;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/swapit/service/chat/ChatSendService.java
+++ b/src/main/java/com/example/swapit/service/chat/ChatSendService.java
@@ -1,4 +1,4 @@
-package com.example.swapit.service;
+package com.example.swapit.service.chat;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -8,6 +8,7 @@ import com.example.swapit.domain.Goods;
 import com.example.swapit.domain.Users;
 import com.example.swapit.domain.dto.chat.ChatStompRequestDto;
 import com.example.swapit.domain.dto.chat.ChatStompResponseDto;
+import com.example.swapit.service.CurrentUserService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/swapit/service/chat/ChatService.java
+++ b/src/main/java/com/example/swapit/service/chat/ChatService.java
@@ -1,4 +1,4 @@
-package com.example.swapit.service;
+package com.example.swapit.service.chat;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/swapit/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/chat/ChatServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.swapit.service;
+package com.example.swapit.service.chat;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,6 +35,7 @@ import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.UsersRepository;
 import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
+import com.example.swapit.service.CurrentUserService;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/swapit/service/chat/StompSubscriptionService.java
+++ b/src/main/java/com/example/swapit/service/chat/StompSubscriptionService.java
@@ -1,0 +1,38 @@
+package com.example.swapit.service.chat;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StompSubscriptionService {
+	private final ConcurrentHashMap<Long, Set<String>> userSubscriptions = new ConcurrentHashMap<>();
+
+	public void subscribe(Long userId, String destination) {
+		userSubscriptions
+			.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet())
+			.add(destination);
+	}
+
+	public void unsubscribe(Long userId, String destination) {
+		Set<String> subs = userSubscriptions.get(userId);
+		if (subs != null) {
+			subs.remove(destination);
+		}
+	}
+
+	public boolean isSubscribed(Long userId, String destination) {
+		return userSubscriptions
+			.getOrDefault(userId, Set.of())
+			.contains(destination);
+	}
+
+	public void removeUser(Long userId) {
+		userSubscriptions.remove(userId);
+	}
+
+	public Set<String> getDestinations(Long userId) {
+		return userSubscriptions.getOrDefault(userId, Set.of());
+	}
+}

--- a/src/main/java/com/example/swapit/service/chat/WebsocketEventListener.java
+++ b/src/main/java/com/example/swapit/service/chat/WebsocketEventListener.java
@@ -1,0 +1,34 @@
+package com.example.swapit.service.chat;
+
+import java.security.Principal;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebsocketEventListener {
+	private final StompSubscriptionService subscriptionService;
+
+	@EventListener
+	public void handleDisconnectEvent(SessionDisconnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		Principal principal = accessor.getUser();
+
+		if (principal == null) {
+			log.warn("[DISCONNECT] Principal 없음 → 세션만 종료: sessionId={}", accessor.getSessionId());
+			return;
+		}
+
+		String userId = principal.getName();
+
+		subscriptionService.removeUser(Long.valueOf(userId)); // userId 기반 정리
+		log.info("[DISCONNECT] 유저 연결 종료: userId={}, sessionId={}", userId, accessor.getSessionId());
+	}
+}

--- a/src/test/java/com/example/swapit/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/swapit/controller/ChatControllerTest.java
@@ -1,8 +1,8 @@
 package com.example.swapit.controller;
 
 import static org.hamcrest.Matchers.*;
-import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -27,7 +27,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.good.TradeInfoDto;
-import com.example.swapit.service.ChatService;
+import com.example.swapit.service.chat.ChatService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
+++ b/src/test/java/com/example/swapit/docs/ChatControllerDocsTest.java
@@ -29,7 +29,7 @@ import com.example.swapit.domain.dto.chat.ChatRoomAddRequestFromTradeDto;
 import com.example.swapit.domain.dto.chat.ChatRoomInfoDto;
 import com.example.swapit.domain.dto.chat.ChatRoomResponseDto;
 import com.example.swapit.domain.dto.good.TradeInfoDto;
-import com.example.swapit.service.ChatServiceImpl;
+import com.example.swapit.service.chat.ChatServiceImpl;
 
 public class ChatControllerDocsTest extends RestDocsTest {
 	private final ChatServiceImpl chatService = mock(ChatServiceImpl.class);

--- a/src/test/java/com/example/swapit/service/ChatServiceTest.java
+++ b/src/test/java/com/example/swapit/service/ChatServiceTest.java
@@ -42,6 +42,7 @@ import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.UsersRepository;
 import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
+import com.example.swapit.service.chat.ChatServiceImpl;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/example/swapit/service/TradesServiceTest.java
+++ b/src/test/java/com/example/swapit/service/TradesServiceTest.java
@@ -40,6 +40,7 @@ import com.example.swapit.repository.ChatRoomsRepository;
 import com.example.swapit.repository.GoodsImagesRepository;
 import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
+import com.example.swapit.service.chat.ChatSendService;
 import com.example.swapit.service.notification.NotificationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#170 

## 📝 작업 내용
- 구독 해제 기능 추가
- subscription 리스트 관리 분리
- websocket 연결 해제 후, 괸리 추가

## 사용 예시
UNSUBSCRIBE 명시적으로 사용할 때, 이런 형식으로 호출

```json
SEND
destination:/app/chat/unsubscribe/2
```


## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify
없습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
