### PR TITLE
[fix] 구글 로그인 idToken으로 검증하도록 변경

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
                         export REDIS_HOST=$REDIS_HOST && \
                         export FIREBASE_CONFIG=\'$(echo $FIREBASE_CONFIG_B64 | base64 -d)\' && \
                         export CLOUDFRONT_URL=$CLOUDFRONT_URL && \
+                        export GOOGLE_WEB_CLIENT_ID=GOOGLE_WEB_CLIENT_ID && \
                         bash ./deploy.sh"
                     '''
                 }

--- a/src/main/java/com/example/swapit/config/GoogleAuthConfig.java
+++ b/src/main/java/com/example/swapit/config/GoogleAuthConfig.java
@@ -1,0 +1,27 @@
+package com.example.swapit.config;
+
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+
+@Configuration
+public class GoogleAuthConfig {
+	@Value("${google.web-client-id}")
+	private String googleWebClientId;
+
+	@Bean
+	public GoogleIdTokenVerifier googleIdTokenVerifier() {
+		return new GoogleIdTokenVerifier.Builder(
+			new NetHttpTransport(),
+			GsonFactory.getDefaultInstance()
+		)
+			.setAudience(Collections.singletonList(googleWebClientId))
+			.build();
+	}
+}

--- a/src/main/java/com/example/swapit/service/AuthService.java
+++ b/src/main/java/com/example/swapit/service/AuthService.java
@@ -9,11 +9,11 @@ public interface AuthService {
 
 	UserResponseDTO getUserInfo(String token);
 
-	TokenDTO googleLogin(String googleAccessToken);
+	TokenDTO googleLogin(String idTokenString);
 
 	TokenDTO kakaoLogin(String kakaoAccessToken);
 
-	Users getGoogleUserInfo(String accessToken);
+	Users getGoogleUserInfo(String idTokenString);
 
 	Users getKakaoUserInfo(String accessToken);
 

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -242,7 +242,7 @@ public class AuthServiceImpl implements AuthService {
 			throw new CustomException(ErrorCode.EXIST_INPROGRESS_TRADE);
 		}
 
-		// callKakaoRevoke(kakaoToken);
+		callKakaoRevoke(kakaoToken);
 		userWithdraw(reason, user);
 	}
 

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -1,9 +1,7 @@
 package com.example.swapit.service;
 
-import java.util.Collections;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -40,8 +38,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.gson.GsonFactory;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -71,11 +67,10 @@ public class AuthServiceImpl implements AuthService {
 	private final RestTemplate restTemplate;
 	private final ApplicationEventPublisher applicationEventPublisher;
 
+	private final GoogleIdTokenVerifier verifier;
+
 	private static final String GOOGLE_LOGIN_INFO = "google";
 	private static final String KAKAO_LOGIN_INFO = "kakao";
-
-	@Value("${google.web-client-id}")
-	private static String GoogleWebClientId;
 
 	@Override
 	public synchronized TokenDTO refresh(String token) {
@@ -156,21 +151,11 @@ public class AuthServiceImpl implements AuthService {
 	@Override
 	public Users getGoogleUserInfo(String idTokenString) {
 		try {
-			GoogleIdTokenVerifier verifier =
-				new GoogleIdTokenVerifier.Builder(
-					new NetHttpTransport(),
-					GsonFactory.getDefaultInstance()
-				)
-					.setAudience(Collections.singletonList(
-						GoogleWebClientId
-					))
-					.build();
-
-			idTokenString = idTokenString.startsWith("Bearer ")
+			String token = idTokenString.startsWith("Bearer ")
 				? idTokenString.substring(7)
 				: idTokenString;
 
-			GoogleIdToken idToken = verifier.verify(idTokenString);
+			GoogleIdToken idToken = verifier.verify(token);
 			if (idToken == null) {
 				throw new CustomException(ErrorCode.GET_USER_INFO_FAIL);
 			}

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -1,7 +1,9 @@
 package com.example.swapit.service;
 
+import java.util.Collections;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +38,10 @@ import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +73,9 @@ public class AuthServiceImpl implements AuthService {
 
 	private static final String GOOGLE_LOGIN_INFO = "google";
 	private static final String KAKAO_LOGIN_INFO = "kakao";
+
+	@Value("${google.web-client-id}")
+	private static String GoogleWebClientId;
 
 	@Override
 	public synchronized TokenDTO refresh(String token) {
@@ -121,9 +130,9 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public TokenDTO googleLogin(String googleAccessToken) {
+	public TokenDTO googleLogin(String idTokenString) {
 		try {
-			Users user = getGoogleUserInfo(googleAccessToken);
+			Users user = getGoogleUserInfo(idTokenString);
 			TokenDTO jwtToken = jwtProvider.createToken(user.getUsersId().toString());
 			jwtService.saveRefreshToken(user, jwtToken.getRefreshToken());
 			return jwtToken;
@@ -145,19 +154,30 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public Users getGoogleUserInfo(String accessToken) {
-		String userInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", accessToken);
-
+	public Users getGoogleUserInfo(String idTokenString) {
 		try {
-			ResponseEntity<String> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET,
-				new HttpEntity<>(headers), String.class);
+			GoogleIdTokenVerifier verifier =
+				new GoogleIdTokenVerifier.Builder(
+					new NetHttpTransport(),
+					GsonFactory.getDefaultInstance()
+				)
+					.setAudience(Collections.singletonList(
+						GoogleWebClientId
+					))
+					.build();
 
-			JsonNode responseJson = new ObjectMapper().readTree(response.getBody());
-			String email = responseJson.get("email").asText();
-			String nickname = responseJson.has("name") ? responseJson.get("name").asText() : "Google User";
-			String profileImageUrl = responseJson.has("picture") ? responseJson.get("picture").asText() : "";
+			idTokenString = idTokenString.startsWith("Bearer ")
+				? idTokenString.substring(7)
+				: idTokenString;
+
+			GoogleIdToken idToken = verifier.verify(idTokenString);
+			if (idToken == null) {
+				throw new CustomException(ErrorCode.GET_USER_INFO_FAIL);
+			}
+			GoogleIdToken.Payload payload = idToken.getPayload();
+			String email = payload.getEmail();
+			String nickname = (String)payload.get("name");
+			String profileImageUrl = (String)payload.get("picture");
 			String role = "ROLE_USER";
 
 			return usersRepository.findByEmail(email)

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -257,7 +257,7 @@ public class AuthServiceImpl implements AuthService {
 			throw new CustomException(ErrorCode.EXIST_INPROGRESS_TRADE);
 		}
 
-		callKakaoRevoke(kakaoToken);
+		// callKakaoRevoke(kakaoToken);
 		userWithdraw(reason, user);
 	}
 

--- a/src/main/java/com/example/swapit/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/swapit/service/AuthServiceImpl.java
@@ -229,7 +229,7 @@ public class AuthServiceImpl implements AuthService {
 			throw new CustomException(ErrorCode.EXIST_INPROGRESS_TRADE);
 		}
 
-		callGoogleRevoke(googleToken);
+		// callGoogleRevoke(googleToken);
 		userWithdraw(reason, user);
 	}
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -35,3 +35,6 @@ cloud:
 
 firebase:
   config-path: firebase-admin.json
+
+google:
+  web-client-id: ${GOOGLE_WEB_CLIENT_ID}

--- a/src/main/resources/application-prd.yaml
+++ b/src/main/resources/application-prd.yaml
@@ -33,3 +33,6 @@ logging:
   level:
     com.example.swapit: debug
     org.springframework.messaging.simp: debug
+
+google:
+  web-client-id: ${GOOGLE_WEB_CLIENT_ID}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -26,3 +26,6 @@ cloud:
 
     cloudfront:
       url: cloudfront
+
+google:
+  web-client-id: ${GOOGLE_WEB_CLIENT_ID}

--- a/src/test/java/com/example/swapit/service/AuthServiceTest.java
+++ b/src/test/java/com/example/swapit/service/AuthServiceTest.java
@@ -42,6 +42,8 @@ import com.example.swapit.repository.WithdrawReasonsRepository;
 import com.example.swapit.repository.good.GoodsRepository;
 import com.example.swapit.repository.trade.TradesRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 
 public class AuthServiceTest {
 
@@ -99,6 +101,9 @@ public class AuthServiceTest {
 
 	@Mock
 	private AwsS3Service awsS3Service;
+
+	@Mock
+	private GoogleIdTokenVerifier verifier;
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -321,24 +326,28 @@ public class AuthServiceTest {
 	@DisplayName("Google 사용자 정보 조회 - 신규 사용자 저장")
 	void getGoogleUserInfoNewUser() throws Exception {
 		// Given
-		String accessToken = "Bearer test_google_token";
-		String googleUserInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
+		String idTokenString = "dummy-id-token";
 		String email = "test@example.com";
 		String nickname = "Test User";
 		String profileImageUrl = "https://test.com/profile.jpg";
 		String role = "ROLE_USER";
 
-		String responseJson = objectMapper.writeValueAsString(
-			Map.of("email", email, "name", nickname, "picture", profileImageUrl));
-		ResponseEntity<String> responseEntity = new ResponseEntity<>(responseJson, HttpStatus.OK);
+		GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
+		payload.setEmail(email);
+		payload.set("name", nickname);
+		payload.set("picture", profileImageUrl);
+		payload.setEmailVerified(true);
 
-		when(restTemplate.exchange(eq(googleUserInfoUrl), eq(HttpMethod.GET), any(HttpEntity.class),
-			eq(String.class))).thenReturn(responseEntity);
+		GoogleIdToken idToken = mock(GoogleIdToken.class);
+		when(idToken.getPayload()).thenReturn(payload);
+
+		when(verifier.verify(idTokenString)).thenReturn(idToken);
+
 		when(usersRepository.findByEmail(email)).thenReturn(Optional.empty());
-		when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(usersRepository.save(any(Users.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		// When
-		Users user = authService.getGoogleUserInfo(accessToken);
+		Users user = authService.getGoogleUserInfo(idTokenString);
 
 		// Then
 		assertNotNull(user);
@@ -356,8 +365,7 @@ public class AuthServiceTest {
 	@DisplayName("Google 사용자 정보 조회 - 기존 사용자 반환")
 	void getGoogleUserInfoExistingUser() throws Exception {
 		// Given
-		String accessToken = "Bearer test_google_token";
-		String googleUserInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
+		String idTokenString = "dummy-id-token";
 		String email = "existing@example.com";
 
 		Users existingUser = Users.builder()
@@ -368,15 +376,18 @@ public class AuthServiceTest {
 			.role("ROLE_USER")
 			.build();
 
-		String responseJson = objectMapper.writeValueAsString(Map.of("email", email));
-		ResponseEntity<String> responseEntity = new ResponseEntity<>(responseJson, HttpStatus.OK);
+		GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
+		payload.setEmail(email);
+		payload.setEmailVerified(true);
 
-		when(restTemplate.exchange(eq(googleUserInfoUrl), eq(HttpMethod.GET), any(HttpEntity.class),
-			eq(String.class))).thenReturn(responseEntity);
+		GoogleIdToken idToken = mock(GoogleIdToken.class);
+		when(idToken.getPayload()).thenReturn(payload);
+
+		when(verifier.verify(idTokenString)).thenReturn(idToken);
 		when(usersRepository.findByEmail(email)).thenReturn(Optional.of(existingUser));
 
 		// When
-		Users user = authService.getGoogleUserInfo(accessToken);
+		Users user = authService.getGoogleUserInfo(idTokenString);
 
 		// Then
 		assertNotNull(user);
@@ -477,30 +488,41 @@ public class AuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("Google 사용자 정보 조회 - 기존 사용자 반환")
-	void getGoogleUserInfo_ExistingUser() throws Exception {
+	@DisplayName("Kakao 사용자 정보 조회 - 기존 사용자 반환")
+	void getKakaoUserInfo_ExistingUser() throws Exception {
 		// Given
-		String accessToken = "Bearer test_google_token";
-		String googleUserInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
-		String email = "existing@example.com";
+		String accessToken = "Bearer test_kakao_token";
+		String kakaoUserInfoUrl = "https://kapi.kakao.com/v2/user/me";
+		String email = "test@example.com";
+		String nickname = "Test User";
+		String profileImageUrl = "https://test.com/profile.jpg";
+		String role = "ROLE_USER";
 
 		Users existingUser = Users.builder()
 			.email(email)
-			.nickname("Existing User")
-			.profileImageUrl("https://test.com/existing.jpg")
-			.loginInfo("google")
-			.role("ROLE_USER")
+			.nickname(nickname)
+			.profileImageUrl(profileImageUrl)
+			.loginInfo("kakao")
+			.role(role)
 			.build();
 
-		String responseJson = objectMapper.writeValueAsString(Map.of("email", email));
+		String responseJson = objectMapper.writeValueAsString(
+			Map.of(
+				"kakao_account", Map.of("email", email),
+				"properties", Map.of(
+					"nickname", nickname,
+					"profile_image", profileImageUrl
+				)
+			)
+		);
 		ResponseEntity<String> responseEntity = new ResponseEntity<>(responseJson, HttpStatus.OK);
 
-		when(restTemplate.exchange(eq(googleUserInfoUrl), eq(HttpMethod.GET), any(HttpEntity.class),
+		when(restTemplate.exchange(eq(kakaoUserInfoUrl), eq(HttpMethod.GET), any(HttpEntity.class),
 			eq(String.class))).thenReturn(responseEntity);
 		when(usersRepository.findByEmail(email)).thenReturn(Optional.of(existingUser));
 
 		// When
-		Users user = authService.getGoogleUserInfo(accessToken);
+		Users user = authService.getKakaoUserInfo(accessToken);
 
 		// Then
 		assertNotNull(user);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없습니다!

## 📝 작업 내용

> 구글 로그인 시 토큰으로 사용자 정보를 가져오는 것이 아니라 idToken에서 사용자 정보를 가져오도록 수정
> 구글 탈퇴 시 revoke는 클라이언트에서 담당

## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] DB에 변경사항이 있나요? 있다면 변경사항을 작성하셨나요?

## 🗄️ Database Modify

> 없습니다!

## 💬 리뷰 요구사항(선택)

> 없습니다!
